### PR TITLE
fix(auth): single-flight no refresh de token e boot de sessão determi…

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,9 +1,12 @@
 import axios from "axios"
+import { jwtDecode } from "jwt-decode"
 import { Configuration, UserApi, FileApi, LoginApi, ResetPasswordApi, SignupApi, ProblemsApi, SubmitApi, ReportBugApi, RollCallApi} from "./sdk"
 
 const BASE_URL = import.meta.env.VITE_API || "https://back.ligadealgoritmos.com"
 
-let accessToken: string = ""
+const TOKEN_STORAGE_KEY = "accessToken"
+
+let accessToken: string = localStorage.getItem(TOKEN_STORAGE_KEY) || ""
 
 export function setAccessToken(token: string) {
   accessToken = token
@@ -15,15 +18,72 @@ export function setUnauthenticatedHandler(handler: () => void) {
   onUnauthenticated = handler
 }
 
+export function isAuthError(error: unknown): boolean {
+  return (
+    axios.isAxiosError(error) &&
+    (error.response?.status === 401 || error.response?.status === 403)
+  )
+}
+
+const EXP_MARGIN_SECONDS = 30
+
+export function isTokenExpired(token: string): boolean {
+  try {
+    const { exp } = jwtDecode<{ exp?: number }>(token)
+    if (!exp) return false
+    return exp <= Date.now() / 1000 + EXP_MARGIN_SECONDS
+  } catch {
+    return true
+  }
+}
+
 const apiConfig = {
   baseURL: BASE_URL,
-  withCredentials: true, 
+  withCredentials: true,
 }
 
 const axiosInstance = axios.create(apiConfig)
 export const api = axiosInstance;
 
 export const rawAxios = axios.create(apiConfig)
+
+function clearSession() {
+  const hadToken = !!accessToken
+  setAccessToken("")
+  localStorage.removeItem(TOKEN_STORAGE_KEY)
+  if (hadToken && onUnauthenticated) onUnauthenticated()
+}
+
+let refreshPromise: Promise<string> | null = null
+
+// Single-flight: requisições concorrentes que tomaram 401 compartilham o mesmo
+// refresh — o backend rotaciona o token, então refreshes paralelos com o mesmo
+// cookie derrubariam a sessão.
+export function refreshAccessToken(): Promise<string> {
+  if (!refreshPromise) {
+    refreshPromise = rawAxios
+      .post("/auth/refresh")
+      .then(res => {
+        const { accessToken: newAccess } = res.data
+
+        setAccessToken(newAccess)
+        localStorage.setItem(TOKEN_STORAGE_KEY, newAccess)
+        return newAccess as string
+      })
+      .catch(err => {
+        // Só rejeição real do refresh token encerra a sessão; erro de
+        // rede/5xx não desloga.
+        if (isAuthError(err)) {
+          clearSession()
+        }
+        throw err
+      })
+      .finally(() => {
+        refreshPromise = null
+      })
+  }
+  return refreshPromise
+}
 
 axiosInstance.interceptors.request.use(config => {
   if (accessToken) {
@@ -38,31 +98,21 @@ axiosInstance.interceptors.response.use(
   async error => {
     const originalRequest = error.config
 
-    if (error.response?.status === 401) {
+    if (error.response?.status === 401 && originalRequest) {
       if (originalRequest._retry) {
-        setAccessToken("")
-        localStorage.removeItem("accessToken")
-        if (onUnauthenticated) onUnauthenticated()
+        clearSession()
         return Promise.reject(error)
       }
 
       originalRequest._retry = true
 
       try {
-        const refreshRes = await rawAxios.post("/auth/refresh")
-        
-        const { accessToken: newAccess } = refreshRes.data
-
-        setAccessToken(newAccess)
-        localStorage.setItem("accessToken", newAccess)
+        const newAccess = await refreshAccessToken()
 
         originalRequest.headers["Authorization"] = `Bearer ${newAccess}`
         return axiosInstance(originalRequest)
-      } catch (err) {
-        setAccessToken("")
-        localStorage.removeItem("accessToken")
-        if (onUnauthenticated) onUnauthenticated()
-        return Promise.reject(err)
+      } catch {
+        return Promise.reject(error)
       }
     }
 

--- a/src/components/profile/PhotoUploadModal.tsx
+++ b/src/components/profile/PhotoUploadModal.tsx
@@ -33,8 +33,13 @@ export function PhotoUploadModal({ isOpen, onClose, type, user }: PhotoUploadMod
         : { bannerUrl: imageUrl };
       
       await client.user.userControllerUpdateUser(user.id, updatePayload);
-      
-      await refetchUser();
+
+      try {
+        await refetchUser();
+      } catch (refetchError) {
+        // O upload já foi salvo; falha só na re-sincronização do perfil
+        console.error(refetchError);
+      }
 
       toast.success(`${type === 'avatar' ? 'Foto de perfil' : 'Banner'} atualizado!`);
       onClose();

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -105,8 +105,13 @@ export function ProfilePage() {
       });
       toast.success("Perfil atualizado com sucesso!");
       setIsEditing(false);
-      await refetchUser();
-    } catch (error) { 
+      try {
+        await refetchUser();
+      } catch (refetchError) {
+        // O update já foi salvo; falha só na re-sincronização do perfil
+        console.error(refetchError);
+      }
+    } catch (error) {
       toast.error("Erro ao guardar as alterações.");
       console.error(error);
     } finally {

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -1,12 +1,18 @@
-import { createContext, useContext, useState, useEffect, useCallback } from "react"
-import client, { setAccessToken, setUnauthenticatedHandler } from "@/api/client"
+import { createContext, useContext, useState, useEffect, useCallback, useRef } from "react"
+import client, {
+  setAccessToken,
+  setUnauthenticatedHandler,
+  refreshAccessToken,
+  isAuthError,
+  isTokenExpired,
+} from "@/api/client"
 import { LoginRequestDTO } from "@/api/sdk"
 import UserWithAccount from "@/types/user.types"
 
 export type AuthContextType = {
   user: UserWithAccount | null
   login: (data: LoginRequestDTO) => Promise<void>
-  logout: () => Promise<void> 
+  logout: () => Promise<void>
   refetchUser: () => Promise<void>
   loading: boolean
   isAuthenticated: boolean
@@ -24,20 +30,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     const storedUser = localStorage.getItem(USER_STORAGE_KEY);
     return storedUser ? JSON.parse(storedUser) : null;
   })
-  
-  const [loading, setLoading] = useState(!user)
+
+  const [loading, setLoading] = useState(true)
+
+  // Espelho do user para handlers registrados uma única vez (evento de storage)
+  const userRef = useRef(user)
+  useEffect(() => {
+    userRef.current = user
+  }, [user])
 
   const fetchUserWithAccount = useCallback(async () => {
-    try {
-      const response = await client.user.userControllerGetMe()
-      const userData = response.data as UserWithAccount;
-      
-      setUser(userData)
-      localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(userData));
-      
-    } catch (error) {
-      console.error("Falha ao sincronizar usuário:", error)
-    }
+    const response = await client.user.userControllerGetMe()
+    const userData = response.data as UserWithAccount;
+
+    setUser(userData)
+    localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(userData));
   }, [])
 
   const logout = useCallback(async () => {
@@ -53,51 +60,104 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   }, [])
 
-  useEffect(() => {
-    const initAuth = async () => {
-      const storedToken = localStorage.getItem(TOKEN_STORAGE_KEY);
-      
-      if (storedToken) {
-        setAccessToken(storedToken)
-        
-        if (!user) {
-            try {
-              await fetchUserWithAccount()
-            } catch (error) {
-               console.error("Erro ao validar sessão:", error)
-               await logout() 
-            }
-        }
+  const syncUser = useCallback(async () => {
+    try {
+      await fetchUserWithAccount()
+    } catch (error) {
+      if (isAuthError(error)) {
+        await logout()
       } else {
-        setUser(null);
-        localStorage.removeItem(USER_STORAGE_KEY);
+        // Erro de rede/5xx: mantém o usuário do cache
+        console.error("Falha ao sincronizar usuário:", error)
       }
-      
-      setLoading(false)
     }
+  }, [fetchUserWithAccount, logout])
 
-    initAuth()
-
+  useEffect(() => {
     setUnauthenticatedHandler(() => {
       logout()
     })
 
+    const initAuth = async () => {
+      const storedToken = localStorage.getItem(TOKEN_STORAGE_KEY);
+
+      if (!storedToken) {
+        setUser(null);
+        localStorage.removeItem(USER_STORAGE_KEY);
+        setLoading(false)
+        return
+      }
+
+      setAccessToken(storedToken)
+
+      if (isTokenExpired(storedToken)) {
+        try {
+          // Renova ANTES do router montar, evitando a rajada de 401 das
+          // queries das rotas protegidas
+          await refreshAccessToken()
+        } catch (error) {
+          if (isAuthError(error)) {
+            // refreshAccessToken já limpou a sessão e disparou o logout
+            setLoading(false)
+            return
+          }
+          // Erro de rede/5xx: segue com o usuário do cache; o interceptor
+          // tenta renovar de novo na próxima requisição
+          console.error("Erro ao renovar sessão:", error)
+        }
+      }
+
+      if (user) {
+        // Perfil em cache: libera a UI e sincroniza em background
+        setLoading(false)
+        void syncUser()
+      } else {
+        await syncUser()
+        setLoading(false)
+      }
+    }
+
+    initAuth()
+
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== TOKEN_STORAGE_KEY) return
+      if (event.newValue) {
+        // Outra aba renovou o token ou logou: adota o token dela
+        setAccessToken(event.newValue)
+        // Aba estava deslogada e outra aba logou: hidrata o usuário
+        if (!userRef.current) {
+          void syncUser()
+        }
+      } else {
+        // Outra aba deslogou: limpa só o estado local
+        setAccessToken("")
+        localStorage.removeItem(USER_STORAGE_KEY)
+        setUser(null)
+      }
+    }
+    window.addEventListener("storage", onStorage)
+
     return () => {
       setUnauthenticatedHandler(() => {})
+      window.removeEventListener("storage", onStorage)
     }
+    // Bootstrap de sessão: deve rodar uma única vez no mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []) 
+  }, [])
 
   async function login(credentials: LoginRequestDTO) {
     try {
       const response = await client.login.loginControllerLogin(credentials)
       const accessToken = response.data.accessToken
-      
+
       localStorage.setItem(TOKEN_STORAGE_KEY, accessToken)
       setAccessToken(accessToken)
 
       await fetchUserWithAccount()
     } catch (error) {
+      // Não deixa token órfão se a busca do usuário falhar após o login
+      setAccessToken("")
+      localStorage.removeItem(TOKEN_STORAGE_KEY)
       console.error("Erro no login:", error)
       throw error
     }
@@ -105,13 +165,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 
   return (
     <AuthContext.Provider
-      value={{ 
-        user, 
-        login, 
-        logout, 
-        refetchUser: fetchUserWithAccount, 
+      value={{
+        user,
+        login,
+        logout,
+        refetchUser: fetchUserWithAccount,
         loading,
-        isAuthenticated: !!user 
+        isAuthenticated: !!user
       }}
     >
       {children}


### PR DESCRIPTION
## 🔗 Task no ClickUp

ID da Task: N/A

## 📝 Descrição das mudanças

Corrige, no lado do cliente, o bug de usuários sendo **deslogados ao retornar ao site** (complementa o PR do backend `fix/sessao-refresh-token`).

**Causa raiz no front:** o interceptor do axios não tinha single-flight — ao voltar ao site com o access token expirado, várias requisições recebiam 401 ao mesmo tempo e cada uma disparava seu próprio `POST /auth/refresh` com o mesmo cookie. Como o backend rotaciona o refresh token a cada uso, só a primeira chamada passava; as demais falhavam e disparavam logout. Além disso, qualquer erro no refresh (inclusive rede/5xx) deslogava o usuário, e no boot as requisições podiam sair sem header `Authorization`.

**Mudanças:**
- **Single-flight**: refreshes concorrentes compartilham uma única promise de `/auth/refresh`; as requisições em 401 aguardam e são refeitas com o token novo
- **Refresh proativo no boot**: token expirado (checado via `jwt-decode`, margem de 30s) é renovado ANTES do router montar — elimina a rajada de 401 na volta ao site
- Erro de rede/5xx **não desloga**; apenas 401/403 reais encerram a sessão (uma única vez, com guard)
- Token em memória inicializado do `localStorage` no load do módulo (sem requisições sem `Authorization` no boot)
- Sincronização entre abas via evento `storage`: login/rotação em uma aba é adotado pelas demais (com hidratação do usuário); logout derruba todas
- `login()` faz rollback do token se a busca do usuário falhar logo após autenticar (sem estado travado)
- `refetchUser` não dispara toast de erro falso quando o update já foi salvo (ProfilePage, PhotoUploadModal)

## 🎯 Tipo de Mudança

- [x] Bug fix (correção de bug)
- [ ] New feature (nova funcionalidade)
- [ ] Documentation (documentação)
- [ ] Refactoring (refatoração)
- [ ] Test (testes)

## 📸 Evidências

- `npm run build` e eslint passando nos arquivos alterados
- Fluxos de refresh/logout/multi-sessão validados contra o backend local com o PR correspondente aplicado

## ✅ Checklist

- [x] Código segue os padrões do projeto
- [x] Self-review foi feito
- [x] Código foi testado localmente