### PR TITLE
fix(auth): aba que perde a sessão derrubava as outras abas e dispositivos

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -61,6 +61,10 @@ let refreshPromise: Promise<string> | null = null
 // cookie derrubariam a sessão.
 export function refreshAccessToken(): Promise<string> {
   if (!refreshPromise) {
+    // O single-flight é por aba. Guardamos o token com que ESTA aba entrou na
+    // corrida para saber, num 401, se outra aba renovou nesse meio-tempo.
+    const tokenBeforeRefresh = accessToken
+
     refreshPromise = rawAxios
       .post("/auth/refresh")
       .then(res => {
@@ -74,6 +78,18 @@ export function refreshAccessToken(): Promise<string> {
         // Só rejeição real do refresh token encerra a sessão; erro de
         // rede/5xx não desloga.
         if (isAuthError(err)) {
+          const storedToken = localStorage.getItem(TOKEN_STORAGE_KEY)
+
+          // Outra aba renovou enquanto esta esperava a resposta. Como o backend
+          // rotaciona o refresh token, o 401 aqui só significa que perdemos a
+          // corrida — não que a sessão morreu. Adota o token da outra aba: sem
+          // isso, o clearSession() apagaria do localStorage o token que ela
+          // acabou de gravar e o evento `storage` derrubaria todas as abas.
+          if (storedToken && storedToken !== tokenBeforeRefresh) {
+            setAccessToken(storedToken)
+            return storedToken
+          }
+
           clearSession()
         }
         throw err

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -47,35 +47,44 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(userData));
   }, [])
 
+  // Encerra a sessão só nesta aba. Usado quando o backend já rejeitou as
+  // credenciais: não há o que revogar, e chamar /auth/logout aqui revogaria os
+  // refresh tokens do usuário em todos os dispositivos.
+  const clearLocalSession = useCallback(() => {
+    setAccessToken("")
+    localStorage.removeItem(TOKEN_STORAGE_KEY)
+    localStorage.removeItem(USER_STORAGE_KEY)
+    setUser(null)
+  }, [])
+
   const logout = useCallback(async () => {
     try {
       await client.login.loginControllerLogout()
     } catch (err) {
       console.error("Erro no logout backend:", err)
     } finally {
-      setAccessToken("")
-      localStorage.removeItem(TOKEN_STORAGE_KEY)
-      localStorage.removeItem(USER_STORAGE_KEY)
-      setUser(null)
+      clearLocalSession()
     }
-  }, [])
+  }, [clearLocalSession])
 
   const syncUser = useCallback(async () => {
     try {
       await fetchUserWithAccount()
     } catch (error) {
       if (isAuthError(error)) {
-        await logout()
+        clearLocalSession()
       } else {
         // Erro de rede/5xx: mantém o usuário do cache
         console.error("Falha ao sincronizar usuário:", error)
       }
     }
-  }, [fetchUserWithAccount, logout])
+  }, [fetchUserWithAccount, clearLocalSession])
 
   useEffect(() => {
+    // Dispara quando o refresh token é rejeitado pelo backend. Limpa só esta
+    // aba: um /auth/logout aqui derrubaria as outras abas e dispositivos.
     setUnauthenticatedHandler(() => {
-      logout()
+      clearLocalSession()
     })
 
     const initAuth = async () => {

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -106,7 +106,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
           await refreshAccessToken()
         } catch (error) {
           if (isAuthError(error)) {
-            // refreshAccessToken já limpou a sessão e disparou o logout
+            // refreshAccessToken já limpou a sessão local pelo handler de
+            // não-autenticado; não chama o backend para não revogar os tokens
+            // dos outros dispositivos
             setLoading(false)
             return
           }


### PR DESCRIPTION
## 🔗 Task no ClickUp

<!-- Informe aqui o ID da task relacionada no ClickUp -->

ID da Task:

## 📝 Descrição das mudanças

Impede que uma aba que perdeu a sessão derrube as outras abas e os outros dispositivos do usuário.

### O que estava acontecendo

Dois caminhos do `AuthProvider` chamavam `logout()` quando o backend rejeitava as credenciais:

- o handler registrado em `setUnauthenticatedHandler`, disparado pelo `clearSession()` do `client.ts` quando o `POST /auth/refresh` volta 401
- o `catch` do `syncUser`, quando o `GET /user/me` volta 401

O `logout()` faz `POST /auth/logout`, e esse endpoint revoga **todos** os refresh tokens do usuário. Ou seja: uma aba perdendo a sessão revogava a sessão de todas as outras.

Isso transformava uma corrida em deslogamento geral. O `refreshPromise` é single-flight **por aba** — cada aba tem o seu. Quando duas abas expiram o access token quase juntas (cenário comum: voltar depois de um tempo com duas abas abertas), as duas mandam `POST /auth/refresh` com o mesmo cookie:

1. A aba A chega primeiro, o backend rotaciona e revoga o refresh token antigo
2. A aba B chega logo depois, com o token que acabou de ser revogado → 401
3. O `clearSession()` da aba B dispara o handler → `POST /auth/logout`
4. O logout revoga **todos** os tokens do usuário, incluindo o que a aba A tinha acabado de receber
5. A aba A cai no próximo request

### O que foi alterado

São dois caminhos de cascata, um em cada arquivo.

**1. `AuthProvider.tsx` — parar de chamar `/auth/logout`.** Quando o backend já rejeitou as credenciais não existe token válido para revogar, então a chamada não tem nada a ganhar — só a perder.

- Novo `clearLocalSession()`, que limpa `accessToken`, `user_data` e o estado do React sem tocar no backend
- `setUnauthenticatedHandler` e o tratamento de 401 do `syncUser` passam a usar ele
- O `logout()` completo, que chama o backend, continua no botão de sair — onde a intenção de encerrar a sessão é explícita e revogar tudo é o comportamento desejado

**2. `client.ts` — parar de apagar o token que a outra aba acabou de gravar.** Tirar o `/auth/logout` do caminho não bastava: no 401 do `/auth/refresh`, o `clearSession()` fazia `localStorage.removeItem("accessToken")`. Isso apaga o token que a aba vencedora já havia gravado e dispara nela o evento `storage` com `newValue` nulo — ramo em que o `AuthProvider` chama `setUser(null)`. A aba que **ganhou** a rotação caía junto, com o refresh token dela intacto no banco.

- `refreshAccessToken()` guarda o token com que a aba entrou na corrida
- Num 401, se o `localStorage` já tem um token diferente, foi outra aba que renovou: a sessão está viva e o 401 só quer dizer que perdemos a corrida. A aba adota o token da irmã e resolve normalmente, sem limpar o storage
- Se o token no storage é o mesmo com que entramos, a sessão morreu de verdade e o `clearSession()` roda como antes
## 🎯 Tipo de Mudança

- [x] Bug fix (correção de bug)
- [ ] New feature (nova funcionalidade)
- [ ] Documentation (documentação)
- [ ] Refactoring (refatoração)
- [ ] Test (testes)

## 📸 Evidências

`tsc`, `eslint` e `vite build` passando sem novos erros ou warnings.

O comportamento foi verificado contra o `client.ts` real, bundlado com esbuild e carregado em **duas instâncias de módulo** — uma por aba, cada uma com seu `accessToken` e seu `refreshPromise` — compartilhando o mesmo `localStorage`, que é exatamente a topologia do browser. O adapter do axios responde 201 para a aba A e 401 para a aba B, reproduzindo a rotação.

O sinal decisivo é a sequência de operações no `localStorage`:

```
antes:  set accessToken=T1 | remove accessToken   <- a aba B apaga o token da aba A
depois: set accessToken=T1                        <- nenhum remove
```

É esse `remove` que dispara o evento `storage` na aba A. Sem ele, não há cascata.

| | Antes | Depois |
|---|---|---|
| Aba A: `POST /auth/refresh` | 201, sessão renovada | 201, sessão renovada |
| Aba B: `POST /auth/refresh` (token já rotacionado) | 401 | 401 |
| Aba B ao tratar o 401 | `POST /auth/logout` → revoga tudo | adota o token da aba A |
| Token no `localStorage` ao fim da corrida | nenhum | o da aba A |
| Handler de não-autenticado da aba B | dispara | não dispara |
| **Aba A no request seguinte** | **401, usuário deslogado** | **segue logada** |
| **Aba B no request seguinte** | **401, usuário deslogado** | **segue logada** |

Dois cenários de controle, para garantir que as invariantes de sessão não regrediram:

| Cenário | Resultado |
|---|---|
| 401 sem outra aba ter renovado (sessão morta de verdade) | token limpo, handler dispara — logout legítimo intacto |
| Erro de rede no `/auth/refresh` | token mantido, handler não dispara — não desloga |

## ✅ Checklist

- [x] Código segue os padrões do projeto
- [x] Self-review foi feito
- [x] Código foi testado localmente

## 📌 Notas adicionais

Isso também resolve a limitação que ficaria para depois: a aba que perde a corrida se recupera sozinha adotando o token da irmã, então **não é mais necessária** uma janela de tolerância na rotação do refresh token no backend.

**Relacionado:** no backend, o PR #13 (`fix/logout-revoga-sessoes-globais`, **já mergeado**) corrigiu o `POST /auth/logout`, que por conta de um `@Req()` mal tipado revogava os refresh tokens de *todos os usuários da plataforma* a cada logout. Os dois atacam o mesmo sintoma — usuários caindo sozinhos — por lados diferentes, e são independentes entre si.

O SDK **não** precisa ser regerado: o PR do backend não mexeu em rota, `operationId`, DTO nem formato de resposta. Rodei `npm run generate:sdk` contra a `main` já mergeada e o diff em `src/api/sdk/` saiu vazio.

