### PR TITLE
feat(problemas): UI do novo modelo de pontuacao competitiva

### DIFF
--- a/src/api/sdk/.openapi-generator/FILES
+++ b/src/api/sdk/.openapi-generator/FILES
@@ -16,6 +16,7 @@ docs/LoginRequestDTO.md
 docs/LoginResponseDTO.md
 docs/ProblemResponseDTO.md
 docs/ProblemsApi.md
+docs/PublicProblemResponseDTO.md
 docs/PublicUserResponseDTO.md
 docs/ReportBugApi.md
 docs/ReportBugServiceDTO.md

--- a/src/api/sdk/api.ts
+++ b/src/api/sdk/api.ts
@@ -73,11 +73,29 @@ export interface CreateProblemDTO {
      */
     'input': string;
     /**
-     * Problem points
+     * Current value of the problem: how many points the next solver earns. Optional — defaults to `initialPoints`. When sent, it is clamped to [floorPoints, initialPoints].
      * @type {number}
      * @memberof CreateProblemDTO
      */
-    'points': number;
+    'points'?: number;
+    /**
+     * Value the problem starts at, and the ceiling of the current value.
+     * @type {number}
+     * @memberof CreateProblemDTO
+     */
+    'initialPoints'?: number;
+    /**
+     * Floor of the current value: once it is reached, solving no longer lowers the problem. Must be less than or equal to `initialPoints`.
+     * @type {number}
+     * @memberof CreateProblemDTO
+     */
+    'floorPoints'?: number;
+    /**
+     * How much the current value drops for each distinct student who solves it.
+     * @type {number}
+     * @memberof CreateProblemDTO
+     */
+    'decrement'?: number;
     /**
      * Problem banner URL
      * @type {string}
@@ -278,7 +296,7 @@ export interface ProblemResponseDTO {
      */
     'input': string;
     /**
-     * Problem points
+     * Current value of the problem: how many points the next solver earns.
      * @type {number}
      * @memberof ProblemResponseDTO
      */
@@ -323,6 +341,115 @@ export interface ProblemResponseDTO {
      * Problem archived
      * @type {boolean}
      * @memberof ProblemResponseDTO
+     */
+    'archived'?: boolean;
+    /**
+     * Value the problem starts at, and the ceiling of the current value.
+     * @type {number}
+     * @memberof ProblemResponseDTO
+     */
+    'initialPoints': number;
+    /**
+     * Floor of the current value: solving never lowers the problem below it.
+     * @type {number}
+     * @memberof ProblemResponseDTO
+     */
+    'floorPoints': number;
+    /**
+     * How much the current value drops for each distinct student who solves it.
+     * @type {number}
+     * @memberof ProblemResponseDTO
+     */
+    'decrement': number;
+}
+/**
+ * 
+ * @export
+ * @interface PublicProblemResponseDTO
+ */
+export interface PublicProblemResponseDTO {
+    /**
+     * Problem ID
+     * @type {string}
+     * @memberof PublicProblemResponseDTO
+     */
+    'id': string;
+    /**
+     * Problem title
+     * @type {string}
+     * @memberof PublicProblemResponseDTO
+     */
+    'title': string;
+    /**
+     * Problem description
+     * @type {string}
+     * @memberof PublicProblemResponseDTO
+     */
+    'description': string;
+    /**
+     * Problem difficulty
+     * @type {string}
+     * @memberof PublicProblemResponseDTO
+     */
+    'difficulty': string;
+    /**
+     * Problem answer
+     * @type {string}
+     * @memberof PublicProblemResponseDTO
+     */
+    'answer': string;
+    /**
+     * Problem input
+     * @type {string}
+     * @memberof PublicProblemResponseDTO
+     */
+    'input': string;
+    /**
+     * Current value of the problem: how many points the next solver earns.
+     * @type {number}
+     * @memberof PublicProblemResponseDTO
+     */
+    'points': number;
+    /**
+     * Problem banner URL
+     * @type {string}
+     * @memberof PublicProblemResponseDTO
+     */
+    'bannerUrl'?: string;
+    /**
+     * Problem creation date
+     * @type {string}
+     * @memberof PublicProblemResponseDTO
+     */
+    'updatedAt': string;
+    /**
+     * Problem creation date
+     * @type {string}
+     * @memberof PublicProblemResponseDTO
+     */
+    'createdAt': string;
+    /**
+     * Number of users who have resolved the problem
+     * @type {number}
+     * @memberof PublicProblemResponseDTO
+     */
+    'resolved': number;
+    /**
+     * Number of submissions for the problem
+     * @type {number}
+     * @memberof PublicProblemResponseDTO
+     */
+    'submissions': number;
+    /**
+     * Problem fixed
+     * @type {boolean}
+     * @memberof PublicProblemResponseDTO
+     */
+    'fixed': boolean;
+    /**
+     * Problem archived
+     * @type {boolean}
+     * @memberof PublicProblemResponseDTO
      */
     'archived'?: boolean;
 }
@@ -620,7 +747,7 @@ export interface SubmitResponseDTO {
      */
     'userId': string;
     /**
-     * Points Earned
+     * Points earned, frozen at the instant the problem was solved. Stays `0` while the problem has not been solved.
      * @type {number}
      * @memberof SubmitResponseDTO
      */
@@ -743,11 +870,29 @@ export interface UpdateProblemDTO {
      */
     'input'?: string;
     /**
-     * Problem points
+     * Current value of the problem: how many points the next solver earns. Optional — defaults to `initialPoints`. When sent, it is clamped to [floorPoints, initialPoints].
      * @type {number}
      * @memberof UpdateProblemDTO
      */
     'points'?: number;
+    /**
+     * Value the problem starts at, and the ceiling of the current value.
+     * @type {number}
+     * @memberof UpdateProblemDTO
+     */
+    'initialPoints'?: number;
+    /**
+     * Floor of the current value: once it is reached, solving no longer lowers the problem. Must be less than or equal to `initialPoints`.
+     * @type {number}
+     * @memberof UpdateProblemDTO
+     */
+    'floorPoints'?: number;
+    /**
+     * How much the current value drops for each distinct student who solves it.
+     * @type {number}
+     * @memberof UpdateProblemDTO
+     */
+    'decrement'?: number;
     /**
      * Problem banner URL
      * @type {string}
@@ -1933,7 +2078,7 @@ export const ProblemsApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async problemControllerGetAllProblems(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<ProblemResponseDTO>>> {
+        async problemControllerGetAllProblems(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<PublicProblemResponseDTO>>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.problemControllerGetAllProblems(options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['ProblemsApi.problemControllerGetAllProblems']?.[localVarOperationServerIndex]?.url;
@@ -1946,7 +2091,7 @@ export const ProblemsApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async problemControllerGetProblemById(id: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ProblemResponseDTO>> {
+        async problemControllerGetProblemById(id: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PublicProblemResponseDTO>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.problemControllerGetProblemById(id, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['ProblemsApi.problemControllerGetProblemById']?.[localVarOperationServerIndex]?.url;
@@ -2021,7 +2166,7 @@ export const ProblemsApiFactory = function (configuration?: Configuration, baseP
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        problemControllerGetAllProblems(options?: RawAxiosRequestConfig): AxiosPromise<Array<ProblemResponseDTO>> {
+        problemControllerGetAllProblems(options?: RawAxiosRequestConfig): AxiosPromise<Array<PublicProblemResponseDTO>> {
             return localVarFp.problemControllerGetAllProblems(options).then((request) => request(axios, basePath));
         },
         /**
@@ -2031,7 +2176,7 @@ export const ProblemsApiFactory = function (configuration?: Configuration, baseP
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        problemControllerGetProblemById(id: string, options?: RawAxiosRequestConfig): AxiosPromise<ProblemResponseDTO> {
+        problemControllerGetProblemById(id: string, options?: RawAxiosRequestConfig): AxiosPromise<PublicProblemResponseDTO> {
             return localVarFp.problemControllerGetProblemById(id, options).then((request) => request(axios, basePath));
         },
         /**
@@ -3343,7 +3488,7 @@ export class SignupApi extends BaseAPI {
 export const SubmitApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
-         * This endpoint allows you to create a new submit
+         * Submits an answer to a problem. A wrong answer only counts an attempt and costs nothing. A right answer earns the current value of the problem, frozen at that instant, and lowers that value for the next solver. Each student can only solve a given problem once.
          * @summary Create Submit
          * @param {CreateSubmitDTO} createSubmitDTO 
          * @param {*} [options] Override http request option.
@@ -3521,7 +3666,7 @@ export const SubmitApiFp = function(configuration?: Configuration) {
     const localVarAxiosParamCreator = SubmitApiAxiosParamCreator(configuration)
     return {
         /**
-         * This endpoint allows you to create a new submit
+         * Submits an answer to a problem. A wrong answer only counts an attempt and costs nothing. A right answer earns the current value of the problem, frozen at that instant, and lowers that value for the next solver. Each student can only solve a given problem once.
          * @summary Create Submit
          * @param {CreateSubmitDTO} createSubmitDTO 
          * @param {*} [options] Override http request option.
@@ -3595,7 +3740,7 @@ export const SubmitApiFactory = function (configuration?: Configuration, basePat
     const localVarFp = SubmitApiFp(configuration)
     return {
         /**
-         * This endpoint allows you to create a new submit
+         * Submits an answer to a problem. A wrong answer only counts an attempt and costs nothing. A right answer earns the current value of the problem, frozen at that instant, and lowers that value for the next solver. Each student can only solve a given problem once.
          * @summary Create Submit
          * @param {CreateSubmitDTO} createSubmitDTO 
          * @param {*} [options] Override http request option.
@@ -3654,7 +3799,7 @@ export const SubmitApiFactory = function (configuration?: Configuration, basePat
  */
 export class SubmitApi extends BaseAPI {
     /**
-     * This endpoint allows you to create a new submit
+     * Submits an answer to a problem. A wrong answer only counts an attempt and costs nothing. A right answer earns the current value of the problem, frozen at that instant, and lowers that value for the next solver. Each student can only solve a given problem once.
      * @summary Create Submit
      * @param {CreateSubmitDTO} createSubmitDTO 
      * @param {*} [options] Override http request option.

--- a/src/api/sdk/docs/CreateProblemDTO.md
+++ b/src/api/sdk/docs/CreateProblemDTO.md
@@ -10,7 +10,10 @@ Name | Type | Description | Notes
 **difficulty** | **string** | Problem difficulty | [default to undefined]
 **answer** | **string** | Problem answer | [default to undefined]
 **input** | **string** | Problem input | [default to undefined]
-**points** | **number** | Problem points | [default to undefined]
+**points** | **number** | Current value of the problem: how many points the next solver earns. Optional — defaults to &#x60;initialPoints&#x60;. When sent, it is clamped to [floorPoints, initialPoints]. | [optional] [default to undefined]
+**initialPoints** | **number** | Value the problem starts at, and the ceiling of the current value. | [optional] [default to undefined]
+**floorPoints** | **number** | Floor of the current value: once it is reached, solving no longer lowers the problem. Must be less than or equal to &#x60;initialPoints&#x60;. | [optional] [default to undefined]
+**decrement** | **number** | How much the current value drops for each distinct student who solves it. | [optional] [default to undefined]
 **bannerUrl** | **string** | Problem banner URL | [default to undefined]
 **archived** | **boolean** | Problem archived | [optional] [default to undefined]
 **fixed** | **boolean** | Problem fixed | [optional] [default to undefined]
@@ -27,6 +30,9 @@ const instance: CreateProblemDTO = {
     answer,
     input,
     points,
+    initialPoints,
+    floorPoints,
+    decrement,
     bannerUrl,
     archived,
     fixed,

--- a/src/api/sdk/docs/ProblemsApi.md
+++ b/src/api/sdk/docs/ProblemsApi.md
@@ -220,7 +220,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **problemControllerGetAllProblems**
-> Array<ProblemResponseDTO> problemControllerGetAllProblems()
+> Array<PublicProblemResponseDTO> problemControllerGetAllProblems()
 
 This endpoint retrieves a list of all problems in the system.
 
@@ -244,7 +244,7 @@ This endpoint does not have any parameters.
 
 ### Return type
 
-**Array<ProblemResponseDTO>**
+**Array<PublicProblemResponseDTO>**
 
 ### Authorization
 
@@ -264,7 +264,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **problemControllerGetProblemById**
-> ProblemResponseDTO problemControllerGetProblemById()
+> PublicProblemResponseDTO problemControllerGetProblemById()
 
 This endpoint retrieves a problem by its ID.
 
@@ -295,7 +295,7 @@ const { status, data } = await apiInstance.problemControllerGetProblemById(
 
 ### Return type
 
-**ProblemResponseDTO**
+**PublicProblemResponseDTO**
 
 ### Authorization
 

--- a/src/api/sdk/docs/PublicProblemResponseDTO.md
+++ b/src/api/sdk/docs/PublicProblemResponseDTO.md
@@ -1,4 +1,4 @@
-# ProblemResponseDTO
+# PublicProblemResponseDTO
 
 
 ## Properties
@@ -19,16 +19,13 @@ Name | Type | Description | Notes
 **submissions** | **number** | Number of submissions for the problem | [default to undefined]
 **fixed** | **boolean** | Problem fixed | [default to undefined]
 **archived** | **boolean** | Problem archived | [optional] [default to undefined]
-**initialPoints** | **number** | Value the problem starts at, and the ceiling of the current value. | [default to undefined]
-**floorPoints** | **number** | Floor of the current value: solving never lowers the problem below it. | [default to undefined]
-**decrement** | **number** | How much the current value drops for each distinct student who solves it. | [default to undefined]
 
 ## Example
 
 ```typescript
-import { ProblemResponseDTO } from './api';
+import { PublicProblemResponseDTO } from './api';
 
-const instance: ProblemResponseDTO = {
+const instance: PublicProblemResponseDTO = {
     id,
     title,
     description,
@@ -43,9 +40,6 @@ const instance: ProblemResponseDTO = {
     submissions,
     fixed,
     archived,
-    initialPoints,
-    floorPoints,
-    decrement,
 };
 ```
 

--- a/src/api/sdk/docs/SubmitApi.md
+++ b/src/api/sdk/docs/SubmitApi.md
@@ -13,7 +13,7 @@ All URIs are relative to *http://localhost*
 # **submitControllerCreateSubmit**
 > SubmitResponseDTO submitControllerCreateSubmit(createSubmitDTO)
 
-This endpoint allows you to create a new submit
+Submits an answer to a problem. A wrong answer only counts an attempt and costs nothing. A right answer earns the current value of the problem, frozen at that instant, and lowers that value for the next solver. Each student can only solve a given problem once.
 
 ### Example
 
@@ -60,6 +60,7 @@ No authorization required
 |-------------|-------------|------------------|
 |**201** | Submit created successfully |  -  |
 |**400** | Bad Request. The input data is invalid or missing. |  -  |
+|**409** | Conflict. The requester has already solved this problem, so nothing is credited. |  -  |
 |**500** | Internal Server Error. An unexpected error occurred while processing the request. |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/src/api/sdk/docs/SubmitResponseDTO.md
+++ b/src/api/sdk/docs/SubmitResponseDTO.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **id** | **string** | Submit ID | [default to undefined]
 **problemId** | **string** | Problem ID | [default to undefined]
 **userId** | **string** | User ID | [default to undefined]
-**pointsEarned** | **number** | Points Earned | [default to undefined]
+**pointsEarned** | **number** | Points earned, frozen at the instant the problem was solved. Stays &#x60;0&#x60; while the problem has not been solved. | [default to undefined]
 **attempts** | **number** | Attempts | [default to undefined]
 **isFinished** | **boolean** | Is Finished | [default to undefined]
 **updatedAt** | **string** | Updated At | [optional] [default to undefined]

--- a/src/api/sdk/docs/UpdateProblemDTO.md
+++ b/src/api/sdk/docs/UpdateProblemDTO.md
@@ -10,7 +10,10 @@ Name | Type | Description | Notes
 **difficulty** | **string** | Problem difficulty | [optional] [default to undefined]
 **answer** | **string** | Problem answer | [optional] [default to undefined]
 **input** | **string** | Problem input | [optional] [default to undefined]
-**points** | **number** | Problem points | [optional] [default to undefined]
+**points** | **number** | Current value of the problem: how many points the next solver earns. Optional — defaults to &#x60;initialPoints&#x60;. When sent, it is clamped to [floorPoints, initialPoints]. | [optional] [default to undefined]
+**initialPoints** | **number** | Value the problem starts at, and the ceiling of the current value. | [optional] [default to undefined]
+**floorPoints** | **number** | Floor of the current value: once it is reached, solving no longer lowers the problem. Must be less than or equal to &#x60;initialPoints&#x60;. | [optional] [default to undefined]
+**decrement** | **number** | How much the current value drops for each distinct student who solves it. | [optional] [default to undefined]
 **bannerUrl** | **string** | Problem banner URL | [optional] [default to undefined]
 **archived** | **boolean** | Problem archived | [optional] [default to undefined]
 **fixed** | **boolean** | Problem fixed | [optional] [default to undefined]
@@ -27,6 +30,9 @@ const instance: UpdateProblemDTO = {
     answer,
     input,
     points,
+    initialPoints,
+    floorPoints,
+    decrement,
     bannerUrl,
     archived,
     fixed,

--- a/src/components/admin/CreateProblemModal.tsx
+++ b/src/components/admin/CreateProblemModal.tsx
@@ -189,6 +189,8 @@ export function CreateProblemModal({ isOpen, onClose, onSuccess }: CreateProblem
                 <Input
                   id="initialPoints"
                   type="number"
+                  min="0"
+                  step="1"
                   value={formData.initialPoints}
                   onChange={(e) => setFormData({...formData, initialPoints: Number(e.target.value)})}
                   className="bg-white/5 border-white/10 text-white focus-visible:ring-primary"
@@ -204,6 +206,8 @@ export function CreateProblemModal({ isOpen, onClose, onSuccess }: CreateProblem
                 <Input
                   id="floorPoints"
                   type="number"
+                  min="0"
+                  step="1"
                   value={formData.floorPoints}
                   onChange={(e) => setFormData({...formData, floorPoints: Number(e.target.value)})}
                   className="bg-white/5 border-white/10 text-white focus-visible:ring-primary"
@@ -219,6 +223,8 @@ export function CreateProblemModal({ isOpen, onClose, onSuccess }: CreateProblem
                 <Input
                   id="decrement"
                   type="number"
+                  min="0"
+                  step="1"
                   value={formData.decrement}
                   onChange={(e) => setFormData({...formData, decrement: Number(e.target.value)})}
                   className="bg-white/5 border-white/10 text-white focus-visible:ring-primary"

--- a/src/components/admin/CreateProblemModal.tsx
+++ b/src/components/admin/CreateProblemModal.tsx
@@ -8,6 +8,14 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import client from "@/api/client";
 import { CreateProblemDTO } from "@/api/sdk";
+import {
+  DEFAULT_DECREMENT,
+  DEFAULT_FLOOR_POINTS,
+  DEFAULT_INITIAL_POINTS,
+  hasScoringErrors,
+  validateScoring,
+  type ScoringErrors,
+} from "@/lib/problem-scoring";
 
 interface CreateProblemModalProps {
   isOpen: boolean;
@@ -19,22 +27,32 @@ export function CreateProblemModal({ isOpen, onClose, onSuccess }: CreateProblem
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [bannerFile, setBannerFile] = useState<File | null>(null);
   
-  const [formData, setFormData] = useState({
+  const [scoringErrors, setScoringErrors] = useState<ScoringErrors>({});
+
+  const emptyForm = {
     title: "",
     description: "",
     difficulty: "EASY",
-    points: 0,
+    initialPoints: DEFAULT_INITIAL_POINTS,
+    floorPoints: DEFAULT_FLOOR_POINTS,
+    decrement: DEFAULT_DECREMENT,
     input: "",
     answer: ""
-  });
+  };
+
+  const [formData, setFormData] = useState(emptyForm);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (!formData.title || !formData.description || !formData.input || !formData.answer) {
       toast.error("Por favor, preenche todos os campos obrigatórios.");
       return;
     }
+
+    const errors = validateScoring(formData);
+    setScoringErrors(errors);
+    if (hasScoringErrors(errors)) return;
 
     setIsSubmitting(true);
     try {
@@ -51,7 +69,9 @@ export function CreateProblemModal({ isOpen, onClose, onSuccess }: CreateProblem
         title: formData.title,
         description: formData.description,
         difficulty: formData.difficulty,
-        points: Number(formData.points),
+        initialPoints: formData.initialPoints,
+        floorPoints: formData.floorPoints,
+        decrement: formData.decrement,
         input: formData.input,
         answer: formData.answer,
         bannerUrl: bannerUrl, 
@@ -65,7 +85,8 @@ export function CreateProblemModal({ isOpen, onClose, onSuccess }: CreateProblem
       
       toast.success("Problema criado com sucesso!");
       
-      setFormData({ title: "", description: "", difficulty: "EASY", points: 0, input: "", answer: "" });
+      setFormData(emptyForm);
+      setScoringErrors({});
       setBannerFile(null);
       
       onSuccess(); 
@@ -140,32 +161,73 @@ export function CreateProblemModal({ isOpen, onClose, onSuccess }: CreateProblem
             />
           </div>
           
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="difficulty" className="text-gray-400">Dificuldade *</Label>
-              <select
-                id="difficulty"
-                value={formData.difficulty}
-                onChange={(e) => setFormData({...formData, difficulty: e.target.value})}
-                className="flex h-10 w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-colors"
-              >
-                <option value="EASY" className="bg-[#0a0a0b] text-emerald-400">Fácil</option>
-                <option value="MEDIUM" className="bg-[#0a0a0b] text-amber-400">Médio</option>
-                <option value="HARD" className="bg-[#0a0a0b] text-red-400">Difícil</option>
-              </select>
-            </div>
+          <div className="space-y-2">
+            <Label htmlFor="difficulty" className="text-gray-400">Dificuldade *</Label>
+            <select
+              id="difficulty"
+              value={formData.difficulty}
+              onChange={(e) => setFormData({...formData, difficulty: e.target.value})}
+              className="flex h-10 w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-colors"
+            >
+              <option value="EASY" className="bg-[#0a0a0b] text-emerald-400">Fácil</option>
+              <option value="MEDIUM" className="bg-[#0a0a0b] text-amber-400">Médio</option>
+              <option value="HARD" className="bg-[#0a0a0b] text-red-400">Difícil</option>
+            </select>
+          </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="points" className="text-gray-400">Pontuação *</Label>
-              <Input 
-                id="points" 
-                type="number"
-                min="0"
-                value={formData.points} 
-                onChange={(e) => setFormData({...formData, points: Number(e.target.value)})}
-                className="bg-white/5 border-white/10 text-white focus-visible:ring-primary" 
-                required
-              />
+          <div className="space-y-3 rounded-xl border border-white/10 bg-white/[0.02] p-4">
+            <div>
+              <Label className="text-gray-300 font-bold">Pontuação da corrida</Label>
+              <p className="text-[11px] text-gray-500 mt-1 leading-relaxed">
+                O problema começa valendo o valor inicial e perde o decremento a cada aluno
+                que o resolve, até parar no piso.
+              </p>
+            </div>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="initialPoints" className="text-gray-400 text-xs">Valor inicial *</Label>
+                <Input
+                  id="initialPoints"
+                  type="number"
+                  value={formData.initialPoints}
+                  onChange={(e) => setFormData({...formData, initialPoints: Number(e.target.value)})}
+                  className="bg-white/5 border-white/10 text-white focus-visible:ring-primary"
+                  required
+                />
+                {scoringErrors.initialPoints && (
+                  <p className="text-[11px] text-red-400 font-medium">{scoringErrors.initialPoints}</p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="floorPoints" className="text-gray-400 text-xs">Piso *</Label>
+                <Input
+                  id="floorPoints"
+                  type="number"
+                  value={formData.floorPoints}
+                  onChange={(e) => setFormData({...formData, floorPoints: Number(e.target.value)})}
+                  className="bg-white/5 border-white/10 text-white focus-visible:ring-primary"
+                  required
+                />
+                {scoringErrors.floorPoints && (
+                  <p className="text-[11px] text-red-400 font-medium">{scoringErrors.floorPoints}</p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="decrement" className="text-gray-400 text-xs">Decremento *</Label>
+                <Input
+                  id="decrement"
+                  type="number"
+                  value={formData.decrement}
+                  onChange={(e) => setFormData({...formData, decrement: Number(e.target.value)})}
+                  className="bg-white/5 border-white/10 text-white focus-visible:ring-primary"
+                  required
+                />
+                {scoringErrors.decrement && (
+                  <p className="text-[11px] text-red-400 font-medium">{scoringErrors.decrement}</p>
+                )}
+              </div>
             </div>
           </div>
 

--- a/src/components/admin/ProblemsTable.tsx
+++ b/src/components/admin/ProblemsTable.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { RefreshCcw, Edit2, Trash2, Eye, EyeOff, AlertTriangle, Search, FileCode2, Star, Pin, PinOff } from "lucide-react";
+import { RefreshCcw, Edit2, Trash2, Eye, EyeOff, AlertTriangle, Search, FileCode2, Star, Pin, PinOff, RotateCcw } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -11,6 +11,14 @@ import client from "@/api/client";
 import { ProblemResponseDTO, UpdateProblemDTO } from "@/api/sdk";
 import { CreateProblemModal } from "@/components/admin/CreateProblemModal";
 import { toast } from "sonner";
+import {
+  DEFAULT_DECREMENT,
+  DEFAULT_FLOOR_POINTS,
+  DEFAULT_INITIAL_POINTS,
+  hasScoringErrors,
+  validateScoring,
+  type ScoringErrors,
+} from "@/lib/problem-scoring";
 
 export function ProblemsTable() {
   const [searchTerm, setSearchTerm] = useState("");
@@ -18,6 +26,8 @@ export function ProblemsTable() {
   const [editingProblem, setEditingProblem] = useState<ProblemResponseDTO | null>(null);
   const [deletingProblem, setDeletingProblem] = useState<ProblemResponseDTO | null>(null);
   const [editFormData, setEditFormData] = useState<UpdateProblemDTO>({});
+  const [scoringErrors, setScoringErrors] = useState<ScoringErrors>({});
+  const [restartingProblem, setRestartingProblem] = useState<ProblemResponseDTO | null>(null);
   const [actionLoading, setActionLoading] = useState(false);
 
   const { data: response, isLoading: loading, refetch } = useQuery({
@@ -54,9 +64,22 @@ export function ProblemsTable() {
     }
   };
 
+  // O valor corrente (`points`) não é editável no formulário: só o botão
+  // "Reiniciar corrida" mexe nele. Mandá-lo junto brigaria com o clamp do back.
+  const editScoring = {
+    initialPoints: editFormData.initialPoints ?? DEFAULT_INITIAL_POINTS,
+    floorPoints: editFormData.floorPoints ?? DEFAULT_FLOOR_POINTS,
+    decrement: editFormData.decrement ?? DEFAULT_DECREMENT,
+  };
+
   const handleUpdateProblem = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!editingProblem) return;
+
+    const errors = validateScoring(editScoring);
+    setScoringErrors(errors);
+    if (hasScoringErrors(errors)) return;
+
     setActionLoading(true);
     try {
       const payload: UpdateProblemDTO = {
@@ -65,7 +88,9 @@ export function ProblemsTable() {
         difficulty: editFormData.difficulty,
         answer: editFormData.answer,
         input: editFormData.input,
-        points: editFormData.points
+        initialPoints: editScoring.initialPoints,
+        floorPoints: editScoring.floorPoints,
+        decrement: editScoring.decrement
       };
       if (editFormData.bannerUrl === "") payload.bannerUrl = "";
 
@@ -75,6 +100,25 @@ export function ProblemsTable() {
       await refetch(); // Recarrega os dados através do React Query
     } catch {
       toast.error("Falha ao atualizar problema.");
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleRestartRace = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!restartingProblem) return;
+    setActionLoading(true);
+    try {
+      await client.problem.problemControllerUpdateProblem(restartingProblem.id, {
+        points: restartingProblem.initialPoints
+      });
+      setRestartingProblem(null);
+      setEditingProblem(null);
+      toast.success("Corrida reiniciada: o problema voltou ao valor inicial.");
+      await refetch();
+    } catch {
+      toast.error("Falha ao reiniciar a corrida.");
     } finally {
       setActionLoading(false);
     }
@@ -194,9 +238,13 @@ export function ProblemsTable() {
                       <td className="px-6 py-4 text-center font-mono text-gray-300">{problem.submissions || 0}</td>
                       <td className="px-6 py-4 text-center font-mono text-emerald-400 font-bold">{problem.resolved || 0}</td>
                       <td className="px-6 py-4">
-                        <div className="flex items-center justify-center gap-1.5 text-amber-400 font-mono font-bold">
+                        <div
+                          className="flex items-center justify-center gap-1.5 text-amber-400 font-mono font-bold"
+                          title={`Valor corrente: ${problem.points} • Inicial: ${problem.initialPoints} • Piso: ${problem.floorPoints} • Decremento: ${problem.decrement}`}
+                        >
                           <Star size={14} className="fill-amber-400/20" />
                           {problem.points || 0}
+                          <span className="text-gray-500 font-normal">/ {problem.initialPoints}</span>
                         </div>
                       </td>
                       <td className="px-6 py-4 text-center text-gray-400 text-xs font-mono">
@@ -214,6 +262,7 @@ export function ProblemsTable() {
                             onClick={() => {
                               setEditingProblem(problem);
                               setEditFormData({ ...problem });
+                              setScoringErrors({});
                             }}
                             className="p-2 bg-white/5 text-gray-300 rounded-md border border-white/5"
                           >
@@ -253,18 +302,75 @@ export function ProblemsTable() {
               <Label className="text-gray-400">Descrição</Label>
               <textarea rows={4} value={editFormData.description || ""} onChange={(e) => setEditFormData({...editFormData, description: e.target.value})} className="w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm" />
             </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <Label className="text-gray-400">Dificuldade</Label>
-                <select value={editFormData.difficulty || ""} onChange={(e) => setEditFormData({...editFormData, difficulty: e.target.value})} className="flex h-10 w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm">
-                  <option value="EASY">Fácil</option>
-                  <option value="MEDIUM">Médio</option>
-                  <option value="HARD">Difícil</option>
-                </select>
+            <div className="space-y-2">
+              <Label className="text-gray-400">Dificuldade</Label>
+              <select value={editFormData.difficulty || ""} onChange={(e) => setEditFormData({...editFormData, difficulty: e.target.value})} className="flex h-10 w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm">
+                <option value="EASY">Fácil</option>
+                <option value="MEDIUM">Médio</option>
+                <option value="HARD">Difícil</option>
+              </select>
+            </div>
+
+            <div className="space-y-3 rounded-xl border border-white/10 bg-white/[0.02] p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <Label className="text-gray-300 font-bold">Pontuação da corrida</Label>
+                  <p className="text-[11px] text-gray-500 mt-1 leading-relaxed">
+                    Vale agora <span className="text-amber-400 font-bold font-mono">{editingProblem?.points}</span> de{" "}
+                    <span className="font-mono">{editingProblem?.initialPoints}</span>. O valor corrente só muda
+                    com os acertos dos alunos ou reiniciando a corrida.
+                  </p>
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => editingProblem && setRestartingProblem(editingProblem)}
+                  className="shrink-0 gap-2 text-[10px] font-bold uppercase tracking-widest text-amber-400 hover:text-amber-300 hover:bg-amber-500/10"
+                >
+                  <RotateCcw size={14} />
+                  Reiniciar corrida
+                </Button>
               </div>
-              <div className="space-y-2">
-                <Label className="text-gray-400">Pontuação</Label>
-                <Input type="number" value={editFormData.points || 0} onChange={(e) => setEditFormData({...editFormData, points: Number(e.target.value)})} className="bg-white/5 border-white/10" />
+              <div className="grid grid-cols-3 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="edit-initialPoints" className="text-gray-400 text-xs">Valor inicial</Label>
+                  <Input
+                    id="edit-initialPoints"
+                    type="number"
+                    value={editScoring.initialPoints}
+                    onChange={(e) => setEditFormData({...editFormData, initialPoints: Number(e.target.value)})}
+                    className="bg-white/5 border-white/10"
+                  />
+                  {scoringErrors.initialPoints && (
+                    <p className="text-[11px] text-red-400 font-medium">{scoringErrors.initialPoints}</p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-floorPoints" className="text-gray-400 text-xs">Piso</Label>
+                  <Input
+                    id="edit-floorPoints"
+                    type="number"
+                    value={editScoring.floorPoints}
+                    onChange={(e) => setEditFormData({...editFormData, floorPoints: Number(e.target.value)})}
+                    className="bg-white/5 border-white/10"
+                  />
+                  {scoringErrors.floorPoints && (
+                    <p className="text-[11px] text-red-400 font-medium">{scoringErrors.floorPoints}</p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-decrement" className="text-gray-400 text-xs">Decremento</Label>
+                  <Input
+                    id="edit-decrement"
+                    type="number"
+                    value={editScoring.decrement}
+                    onChange={(e) => setEditFormData({...editFormData, decrement: Number(e.target.value)})}
+                    className="bg-white/5 border-white/10"
+                  />
+                  {scoringErrors.decrement && (
+                    <p className="text-[11px] text-red-400 font-medium">{scoringErrors.decrement}</p>
+                  )}
+                </div>
               </div>
             </div>
 
@@ -297,6 +403,24 @@ export function ProblemsTable() {
             <DialogFooter className="pt-4 border-t border-white/10 mt-6">
               <Button type="button" variant="ghost" onClick={() => setEditingProblem(null)}>Cancelar</Button>
               <Button type="submit" disabled={actionLoading} className="bg-primary">{actionLoading ? "A guardar..." : "Guardar Alterações"}</Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!restartingProblem} onOpenChange={(open) => !open && setRestartingProblem(null)}>
+        <DialogContent className="bg-[#0a0a0b] border-amber-500/20 text-white sm:max-w-[425px]">
+          <DialogHeader><DialogTitle className="text-amber-400 flex items-center gap-2"><RotateCcw size={20} /> Reiniciar Corrida</DialogTitle></DialogHeader>
+          <form onSubmit={handleRestartRace} className="space-y-4 py-2">
+            <p className="text-sm text-gray-400">
+              O problema <strong>{restartingProblem?.title}</strong> volta a valer{" "}
+              <strong className="text-amber-400 font-mono">{restartingProblem?.initialPoints}</strong> pontos
+              (vale <span className="font-mono">{restartingProblem?.points}</span> agora). Quem já resolveu mantém
+              os pontos que ganhou.
+            </p>
+            <DialogFooter>
+              <Button type="button" variant="ghost" onClick={() => setRestartingProblem(null)}>Cancelar</Button>
+              <Button type="submit" disabled={actionLoading} className="bg-amber-600 hover:bg-amber-500">{actionLoading ? "A reiniciar..." : "Sim, Reiniciar"}</Button>
             </DialogFooter>
           </form>
         </DialogContent>

--- a/src/components/admin/ProblemsTable.tsx
+++ b/src/components/admin/ProblemsTable.tsx
@@ -66,10 +66,13 @@ export function ProblemsTable() {
 
   // O valor corrente (`points`) não é editável no formulário: só o botão
   // "Reiniciar corrida" mexe nele. Mandá-lo junto brigaria com o clamp do back.
+  // O fallback sai do problema que está aberto, não dos defaults: cair nos
+  // defaults gravaria 100/70/5 em cima da configuração real do problema.
   const editScoring = {
-    initialPoints: editFormData.initialPoints ?? DEFAULT_INITIAL_POINTS,
-    floorPoints: editFormData.floorPoints ?? DEFAULT_FLOOR_POINTS,
-    decrement: editFormData.decrement ?? DEFAULT_DECREMENT,
+    initialPoints:
+      editFormData.initialPoints ?? editingProblem?.initialPoints ?? DEFAULT_INITIAL_POINTS,
+    floorPoints: editFormData.floorPoints ?? editingProblem?.floorPoints ?? DEFAULT_FLOOR_POINTS,
+    decrement: editFormData.decrement ?? editingProblem?.decrement ?? DEFAULT_DECREMENT,
   };
 
   const handleUpdateProblem = async (e: React.FormEvent) => {
@@ -337,6 +340,8 @@ export function ProblemsTable() {
                   <Input
                     id="edit-initialPoints"
                     type="number"
+                    min="0"
+                    step="1"
                     value={editScoring.initialPoints}
                     onChange={(e) => setEditFormData({...editFormData, initialPoints: Number(e.target.value)})}
                     className="bg-white/5 border-white/10"
@@ -350,6 +355,8 @@ export function ProblemsTable() {
                   <Input
                     id="edit-floorPoints"
                     type="number"
+                    min="0"
+                    step="1"
                     value={editScoring.floorPoints}
                     onChange={(e) => setEditFormData({...editFormData, floorPoints: Number(e.target.value)})}
                     className="bg-white/5 border-white/10"
@@ -363,6 +370,8 @@ export function ProblemsTable() {
                   <Input
                     id="edit-decrement"
                     type="number"
+                    min="0"
+                    step="1"
                     value={editScoring.decrement}
                     onChange={(e) => setEditFormData({...editFormData, decrement: Number(e.target.value)})}
                     className="bg-white/5 border-white/10"

--- a/src/components/problems/ProblemCard.tsx
+++ b/src/components/problems/ProblemCard.tsx
@@ -3,15 +3,18 @@ import { Badge } from "@/components/ui/badge";
 import { Terminal, Star, CheckCircle2, Check } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 import { PublicProblemResponseDTO } from "@/api/sdk";
+import { CURRENT_VALUE_HINT } from "@/lib/problem-scoring";
 import { cn } from "@/lib/utils";
 
 interface ProblemCardProps {
   problem: PublicProblemResponseDTO;
-  isFinished?: boolean;  
-  onClick?: (problem: PublicProblemResponseDTO) => void; 
+  isFinished?: boolean;
+  /** Pontos que o aluno congelou ao acertar. Só faz sentido com `isFinished`. */
+  pointsEarned?: number;
+  onClick?: (problem: PublicProblemResponseDTO) => void;
 }
 
-export function ProblemCard({ problem, isFinished, onClick }: ProblemCardProps) {
+export function ProblemCard({ problem, isFinished, pointsEarned, onClick }: ProblemCardProps) {
   const navigate = useNavigate();
   const difficultyLevel = problem.difficulty || "MEDIUM";
   
@@ -62,10 +65,25 @@ export function ProblemCard({ problem, isFinished, onClick }: ProblemCardProps) 
           <Badge className={cn("px-2.5 py-0.5 font-bold text-[9px] tracking-widest uppercase rounded-lg border shadow-lg", difficultyStyles)}>
             {problem.difficulty}
           </Badge>
-          <div className="flex items-center gap-1.5 px-2.5 py-0.5 rounded-lg bg-black/60 border border-white/10 text-[10px] font-bold text-primary backdrop-blur-md">
-            <Star size={10} fill="currentColor" />
-            {problem.points} <span className="text-[8px] opacity-50">PTS</span>
-          </div>
+          {isFinished ? (
+            // Quem já resolveu vê o que ganhou, não o valor de agora: o card e a
+            // tela do problema têm de mostrar o mesmo número.
+            <div
+              title={`Você ganhou ${pointsEarned ?? 0} pontos neste desafio.`}
+              className="flex items-center gap-1.5 px-2.5 py-0.5 rounded-lg bg-black/60 border border-emerald-500/30 text-[10px] font-bold text-emerald-400 backdrop-blur-md"
+            >
+              <Star size={10} fill="currentColor" />
+              {pointsEarned ?? 0} <span className="text-[8px] opacity-50">GANHOS</span>
+            </div>
+          ) : (
+            <div
+              title={CURRENT_VALUE_HINT}
+              className="flex items-center gap-1.5 px-2.5 py-0.5 rounded-lg bg-black/60 border border-white/10 text-[10px] font-bold text-primary backdrop-blur-md"
+            >
+              <Star size={10} fill="currentColor" />
+              {problem.points} <span className="text-[8px] opacity-50">PTS</span>
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/components/problems/ProblemCard.tsx
+++ b/src/components/problems/ProblemCard.tsx
@@ -2,13 +2,13 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Terminal, Star, CheckCircle2, Check } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
-import { ProblemResponseDTO } from "@/api/sdk";
+import { PublicProblemResponseDTO } from "@/api/sdk";
 import { cn } from "@/lib/utils";
 
 interface ProblemCardProps {
-  problem: ProblemResponseDTO;
+  problem: PublicProblemResponseDTO;
   isFinished?: boolean;  
-  onClick?: (problem: ProblemResponseDTO) => void; 
+  onClick?: (problem: PublicProblemResponseDTO) => void; 
 }
 
 export function ProblemCard({ problem, isFinished, onClick }: ProblemCardProps) {

--- a/src/lib/problem-scoring.ts
+++ b/src/lib/problem-scoring.ts
@@ -1,0 +1,66 @@
+/**
+ * Regras da corrida de pontuação do problema, num lugar só.
+ *
+ * O `points` do problema é o valor **corrente**: quanto o próximo aluno a
+ * resolver leva. Ele cai `decrement` a cada aluno distinto que resolve, com
+ * piso em `floorPoints` e teto em `initialPoints`.
+ *
+ * Os formulários de criação e de edição do admin precisam exatamente da mesma
+ * validação, e o repo já teve o problema de cópias divergentes da mesma regra
+ * espalhadas pelas telas — por isso ela nasce com um dono só.
+ *
+ * As regras espelham o back: `@IsInt() @Min(0)` em cada campo do DTO e
+ * `floorPoints <= initialPoints` conferido no service (400 na criação e na
+ * edição). O `decrement` não é comparado com nada, e `0` é válido tanto no
+ * piso quanto no decremento.
+ */
+
+export const DEFAULT_INITIAL_POINTS = 100;
+export const DEFAULT_FLOOR_POINTS = 70;
+export const DEFAULT_DECREMENT = 5;
+
+export interface ScoringValues {
+  initialPoints: number;
+  floorPoints: number;
+  decrement: number;
+}
+
+export type ScoringErrors = Partial<Record<keyof ScoringValues, string>>;
+
+const FIELD_LABELS: Record<keyof ScoringValues, string> = {
+  initialPoints: "O valor inicial",
+  floorPoints: "O piso",
+  decrement: "O decremento",
+};
+
+/**
+ * Devolve as mensagens de erro por campo. Objeto vazio = configuração válida.
+ */
+export function validateScoring(values: ScoringValues): ScoringErrors {
+  const errors: ScoringErrors = {};
+
+  (Object.keys(FIELD_LABELS) as (keyof ScoringValues)[]).forEach((field) => {
+    const value = values[field];
+    if (!Number.isFinite(value) || !Number.isInteger(value)) {
+      errors[field] = `${FIELD_LABELS[field]} tem de ser um número inteiro.`;
+      return;
+    }
+    if (value < 0) {
+      errors[field] = `${FIELD_LABELS[field]} não pode ser negativo.`;
+    }
+  });
+
+  if (!errors.floorPoints && !errors.initialPoints && values.floorPoints > values.initialPoints) {
+    errors.floorPoints = "O piso não pode ser maior que o valor inicial.";
+  }
+
+  return errors;
+}
+
+export function hasScoringErrors(errors: ScoringErrors): boolean {
+  return Object.keys(errors).length > 0;
+}
+
+/** Texto do `?` na tela do problema e do hover da coluna do catálogo admin. */
+export const CURRENT_VALUE_HINT =
+  "Este é o valor de agora: o próximo aluno a resolver leva esses pontos, e o problema vale menos a cada aluno que resolve.";

--- a/src/lib/problem-scoring.ts
+++ b/src/lib/problem-scoring.ts
@@ -61,6 +61,6 @@ export function hasScoringErrors(errors: ScoringErrors): boolean {
   return Object.keys(errors).length > 0;
 }
 
-/** Texto do `?` na tela do problema e do hover da coluna do catálogo admin. */
+/** Texto do `?` na tela do problema e do hover do valor corrente no card. */
 export const CURRENT_VALUE_HINT =
   "Este é o valor de agora: o próximo aluno a resolver leva esses pontos, e o problema vale menos a cada aluno que resolve.";

--- a/src/pages/ProblemDetailsPage.tsx
+++ b/src/pages/ProblemDetailsPage.tsx
@@ -1,18 +1,21 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
-import { 
-   Download, Send, FileText, 
+import {
+   Download, Send, FileText,
   Users, Trophy, Activity, CheckCircle2, ArrowLeft, Loader2, Eye, EyeOff,
-  XCircle, PartyPopper, CheckCircle, Hash
+  XCircle, PartyPopper, CheckCircle, Hash, WifiOff
 } from "lucide-react";
 import { Link, useParams, useNavigate } from "@tanstack/react-router";
+import { isAxiosError } from "axios";
 import { useAuth } from "@/providers/AuthProvider";
 import client from "@/api/client";
-import { ProblemResponseDTO, SubmitResponseDTO } from "@/api/sdk";
+import { PublicProblemResponseDTO, SubmitResponseDTO } from "@/api/sdk";
+import { CURRENT_VALUE_HINT } from "@/lib/problem-scoring";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw"; 
 import remarkGfm from "remark-gfm"; 
@@ -25,64 +28,50 @@ export function ProblemDetailsPage() {
   
   const isAdmin = user?.role === 'ADMIN';
 
-  const [problem, setProblem] = useState<ProblemResponseDTO & { isFinished?: boolean } | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const queryClient = useQueryClient();
+  const cleanId = problemId?.replace('%23', '').replace('#', '');
+
   const [isSubmitting, setIsSubmitting] = useState(false);
-  
+
   const [userAnswer, setUserAnswer] = useState("");
   const [showAnswer, setShowAnswer] = useState(false);
 
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [showErrorModal, setShowErrorModal] = useState(false);
+  const [showAlreadySolvedModal, setShowAlreadySolvedModal] = useState(false);
+  const [showNetworkErrorModal, setShowNetworkErrorModal] = useState(false);
   const [earnedPoints, setEarnedPoints] = useState(0);
 
-  useEffect(() => {
-    let isMounted = true;
-    
-    async function fetchProblemData() {
-      const cleanId = problemId?.replace('%23', '').replace('#', ''); 
-      if (!cleanId) return;
-      
-      setIsLoading(true);
+  // O admin recebe um superconjunto do payload público, então a mesma variável
+  // serve às duas rotas sem cast.
+  const { data: problemResponse, isLoading } = useQuery({
+    queryKey: ['problem', cleanId, isAdmin],
+    queryFn: (): Promise<{ data: PublicProblemResponseDTO }> =>
+      isAdmin
+        ? client.problem.problemControllerGetAdminProblemById(String(cleanId))
+        : client.problem.problemControllerGetProblemById(String(cleanId)),
+    enabled: !!cleanId,
+  });
 
-      try {
-        let problemResponse;
-        if (isAdmin) {
-          problemResponse = await client.problem.problemControllerGetAdminProblemById(cleanId);
-        } else {
-          problemResponse = await client.problem.problemControllerGetProblemById(cleanId);
-        }
+  // Mesma chave da listagem de problemas: invalidar aqui tem de alcançar as duas telas.
+  const { data: submissionsResponse } = useQuery({
+    queryKey: ['submissions', user?.id],
+    queryFn: () => client.submit.submitControllerGetSubmitByUserId(String(user?.id)),
+    enabled: !!(isAuthenticated && user?.id),
+  });
 
-        let finished = false;
+  const problem = problemResponse?.data ?? null;
 
-        if (isAuthenticated && user?.id) {
-          try {
-            const submitsResponse = await client.submit.submitControllerGetSubmitByUserId(String(user.id));
-            const submissoes = submitsResponse.data as SubmitResponseDTO[];
-            finished = submissoes.some(
-              (s) => s.problemId === cleanId && s.isFinished === true
-            );
-          } catch (e) {
-            console.error("Erro ao validar submissões prévias:", e);
-          }
-        }
+  const userSubmission = ((submissionsResponse?.data as SubmitResponseDTO[]) || []).find(
+    (s) => s.problemId === cleanId && s.isFinished === true
+  );
+  const isFinished = !!userSubmission;
 
-        if (isMounted) {
-          setProblem({
-            ...(problemResponse.data as ProblemResponseDTO),
-            isFinished: finished
-          });
-        }
-      } catch (error: unknown) {
-        console.error("Erro ao buscar detalhes do problema:", error);
-      } finally {
-        if (isMounted) setIsLoading(false);
-      }
-    }
-
-    fetchProblemData();
-    return () => { isMounted = false; };
-  }, [problemId, isAdmin, isAuthenticated, user?.id]);
+  const invalidateAfterSubmit = () => {
+    queryClient.invalidateQueries({ queryKey: ['problem', cleanId] });
+    queryClient.invalidateQueries({ queryKey: ['problems'] });
+    queryClient.invalidateQueries({ queryKey: ['submissions', user?.id] });
+  };
 
   if (isLoading) {
     return (
@@ -136,19 +125,27 @@ export function ProblemDetailsPage() {
         answer: userAnswer
       });
 
-      const { isFinished, pointsEarned } = response.data;
+      const { isFinished: solved, pointsEarned } = response.data;
 
-      if (isFinished) {
+      if (solved) {
         setEarnedPoints(pointsEarned || 0);
         setShowSuccessModal(true);
-        setUserAnswer(""); 
-        setProblem(prev => prev ? { ...prev, isFinished: true } : null);
+        setUserAnswer("");
+        invalidateAfterSubmit();
       } else {
         setShowErrorModal(true);
       }
     } catch (error) {
       console.error("Erro ao submeter resposta:", error);
-      setShowErrorModal(true);
+      // Ramifica pelo status, nunca pela mensagem: o corpo do 409 traz texto
+      // interno do back.
+      if (isAxiosError(error) && error.response?.status === 409) {
+        setShowAlreadySolvedModal(true);
+        setUserAnswer("");
+        invalidateAfterSubmit();
+      } else {
+        setShowNetworkErrorModal(true);
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -177,11 +174,26 @@ export function ProblemDetailsPage() {
                <Badge className={cn("px-4 py-1.5 font-bold text-[10px] tracking-widest uppercase rounded-xl border-2 shadow-lg", currentDiffStyle)}>
                   {problemDifficulty}
                </Badge>
-               <div className="flex items-center gap-2 px-4 py-1.5 rounded-xl bg-primary/20 border border-primary/30 text-sm font-bold text-white backdrop-blur-md">
-                  <Trophy size={14} className="text-primary" />
-                  {problem.points} <span className="text-[10px] opacity-60 ml-0.5">PONTOS</span>
-               </div>
-               {problem.isFinished && (
+               {isFinished ? (
+                 <div className="flex items-center gap-2 px-4 py-1.5 rounded-xl bg-emerald-500/20 border border-emerald-500/30 text-sm font-bold text-white backdrop-blur-md">
+                    <Trophy size={14} className="text-emerald-400" />
+                    {userSubmission?.pointsEarned ?? 0}{" "}
+                    <span className="text-[10px] opacity-60 ml-0.5">PONTOS QUE VOCÊ GANHOU</span>
+                 </div>
+               ) : (
+                 <div className="flex items-center gap-2 px-4 py-1.5 rounded-xl bg-primary/20 border border-primary/30 text-sm font-bold text-white backdrop-blur-md">
+                    <Trophy size={14} className="text-primary" />
+                    {problem.points} <span className="text-[10px] opacity-60 ml-0.5">PONTOS</span>
+                    <span
+                      title={CURRENT_VALUE_HINT}
+                      aria-label={CURRENT_VALUE_HINT}
+                      className="ml-1 h-4 w-4 shrink-0 flex items-center justify-center rounded-full border border-white/30 text-[9px] font-black text-white/70 cursor-help"
+                    >
+                      ?
+                    </span>
+                 </div>
+               )}
+               {isFinished && (
                  <Badge className="px-4 py-1.5 font-bold text-[10px] tracking-widest uppercase rounded-xl border-2 border-emerald-500/50 bg-emerald-500/20 text-emerald-400 shadow-lg animate-in zoom-in duration-300">
                    <CheckCircle size={12} className="mr-1.5" />
                    Resolvido
@@ -285,12 +297,15 @@ export function ProblemDetailsPage() {
         <div className="mt-auto pt-6 space-y-4">
           {!isAuthenticated ? (
              <Button onClick={() => navigate({ to: '/login' })} className="w-full h-16 rounded-[24px] bg-primary/20 hover:bg-primary border border-primary/50 text-white font-bold">Faça Login para Enviar</Button>
-          ) : problem.isFinished ? (
+          ) : isFinished ? (
             <div className="p-6 rounded-[32px] border-2 border-emerald-500/20 bg-emerald-500/5 flex flex-col items-center text-center space-y-3 animate-in fade-in slide-in-from-bottom-4 duration-500">
               <div className="h-12 w-12 rounded-full bg-emerald-500/10 flex items-center justify-center text-emerald-500">
                 <CheckCircle size={28} />
               </div>
               <h4 className="text-base font-black text-white uppercase tracking-tight">Desafio Resolvido</h4>
+              <p className="text-xs text-gray-400 font-medium">
+                Você ganhou <span className="text-emerald-400 font-black font-mono">{userSubmission?.pointsEarned ?? 0}</span> pontos neste desafio.
+              </p>
               <Button onClick={() => navigate({ to: '/problemas' })} variant="outline" className="w-full rounded-2xl border-white/10 hover:bg-white/5 text-[10px] font-bold uppercase tracking-widest h-12">Próximo Desafio</Button>
             </div>
           ) : (
@@ -333,6 +348,40 @@ export function ProblemDetailsPage() {
           </DialogHeader>
           <DialogFooter className="mt-4">
             <Button onClick={() => setShowSuccessModal(false)} className="w-full rounded-2xl bg-emerald-600 hover:bg-emerald-500 font-bold">Uhuul!</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showAlreadySolvedModal} onOpenChange={setShowAlreadySolvedModal}>
+        <DialogContent className="bg-[#0a0a0b] border-primary/30 text-white max-w-sm rounded-[32px]">
+          <DialogHeader className="flex flex-col items-center gap-4">
+            <div className="h-20 w-20 rounded-full bg-primary/10 flex items-center justify-center text-primary shadow-2xl shadow-primary/20">
+              <CheckCircle size={40} />
+            </div>
+            <DialogTitle className="text-2xl font-black tracking-tighter text-primary text-center">VOCÊ JÁ RESOLVEU ESTE PROBLEMA</DialogTitle>
+            <DialogDescription className="text-center text-gray-400 font-medium">
+              Cada desafio conta uma vez só. Os pontos que você ganhou continuam valendo — escolha outro problema para somar mais.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="mt-4">
+            <Button onClick={() => setShowAlreadySolvedModal(false)} className="w-full rounded-2xl bg-primary hover:bg-primary/90 font-bold">Entendi</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showNetworkErrorModal} onOpenChange={setShowNetworkErrorModal}>
+        <DialogContent className="bg-[#0a0a0b] border-amber-500/30 text-white max-w-sm rounded-[32px]">
+          <DialogHeader className="flex flex-col items-center gap-4">
+            <div className="h-20 w-20 rounded-full bg-amber-500/10 flex items-center justify-center text-amber-500 shadow-2xl shadow-amber-500/20">
+              <WifiOff size={40} />
+            </div>
+            <DialogTitle className="text-2xl font-black tracking-tighter text-amber-400 text-center">FALHA AO ENVIAR</DialogTitle>
+            <DialogDescription className="text-center text-gray-400 font-medium">
+              Não conseguimos enviar a sua resposta. Isto não é um erro na resposta — verifique a ligação e tente de novo.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="mt-4">
+            <Button onClick={() => setShowNetworkErrorModal(false)} className="w-full rounded-2xl bg-amber-600 hover:bg-amber-500 font-bold">Tentar de Novo</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/pages/ProblemDetailsPage.tsx
+++ b/src/pages/ProblemDetailsPage.tsx
@@ -21,6 +21,30 @@ import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm"; 
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 
+/**
+ * Por que o envio falhou — nunca por que a resposta está errada. Os três casos
+ * pedem textos diferentes: falar de ligação num 401 é mentir para o aluno.
+ */
+type SubmitFailure = 'network' | 'expired' | 'rejected';
+
+function classifySubmitFailure(error: unknown): SubmitFailure {
+  if (!isAxiosError(error)) return 'network';
+  const status = error.response?.status;
+  // Sem `response` é rede caída/timeout; 5xx é o servidor de pé mas quebrado.
+  if (status === undefined || status >= 500) return 'network';
+  if (status === 401) return 'expired';
+  return 'rejected';
+}
+
+const SUBMIT_FAILURE_MESSAGE: Record<SubmitFailure, string> = {
+  network:
+    "Não conseguimos enviar a sua resposta. Isto não é um erro na resposta — verifique a ligação e tente de novo.",
+  expired:
+    "A sua sessão expirou antes de o envio chegar. Isto não é um erro na resposta — entre de novo e reenvie.",
+  rejected:
+    "O servidor recusou o envio. Isto não é um erro na resposta — recarregue a página e tente de novo.",
+};
+
 export function ProblemDetailsPage() {
   const { problemId } = useParams({ strict: false });
   const navigate = useNavigate();
@@ -39,7 +63,7 @@ export function ProblemDetailsPage() {
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [showErrorModal, setShowErrorModal] = useState(false);
   const [showAlreadySolvedModal, setShowAlreadySolvedModal] = useState(false);
-  const [showNetworkErrorModal, setShowNetworkErrorModal] = useState(false);
+  const [submitFailure, setSubmitFailure] = useState<SubmitFailure | null>(null);
   const [earnedPoints, setEarnedPoints] = useState(0);
 
   // O admin recebe um superconjunto do payload público, então a mesma variável
@@ -144,7 +168,7 @@ export function ProblemDetailsPage() {
         setUserAnswer("");
         invalidateAfterSubmit();
       } else {
-        setShowNetworkErrorModal(true);
+        setSubmitFailure(classifySubmitFailure(error));
       }
     } finally {
       setIsSubmitting(false);
@@ -369,7 +393,7 @@ export function ProblemDetailsPage() {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={showNetworkErrorModal} onOpenChange={setShowNetworkErrorModal}>
+      <Dialog open={!!submitFailure} onOpenChange={(open) => !open && setSubmitFailure(null)}>
         <DialogContent className="bg-[#0a0a0b] border-amber-500/30 text-white max-w-sm rounded-[32px]">
           <DialogHeader className="flex flex-col items-center gap-4">
             <div className="h-20 w-20 rounded-full bg-amber-500/10 flex items-center justify-center text-amber-500 shadow-2xl shadow-amber-500/20">
@@ -377,11 +401,11 @@ export function ProblemDetailsPage() {
             </div>
             <DialogTitle className="text-2xl font-black tracking-tighter text-amber-400 text-center">FALHA AO ENVIAR</DialogTitle>
             <DialogDescription className="text-center text-gray-400 font-medium">
-              Não conseguimos enviar a sua resposta. Isto não é um erro na resposta — verifique a ligação e tente de novo.
+              {submitFailure ? SUBMIT_FAILURE_MESSAGE[submitFailure] : ""}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="mt-4">
-            <Button onClick={() => setShowNetworkErrorModal(false)} className="w-full rounded-2xl bg-amber-600 hover:bg-amber-500 font-bold">Tentar de Novo</Button>
+            <Button onClick={() => setSubmitFailure(null)} className="w-full rounded-2xl bg-amber-600 hover:bg-amber-500 font-bold">Tentar de Novo</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/pages/ProblemsPage.tsx
+++ b/src/pages/ProblemsPage.tsx
@@ -9,7 +9,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import client from "@/api/client";
-import { ProblemResponseDTO, SubmitResponseDTO } from "@/api/sdk";
+import { PublicProblemResponseDTO, SubmitResponseDTO } from "@/api/sdk";
 import { useAuth } from "@/providers/AuthProvider";
 
 import {
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/dialog";
 
 export function ProblemsPage() {
-  const [, setSelectedProblem] = useState<ProblemResponseDTO | null>(null);
+  const [, setSelectedProblem] = useState<PublicProblemResponseDTO | null>(null);
   const { user, isAuthenticated } = useAuth();
   
   const [nameFilter, setNameFilter] = useState("");
@@ -40,7 +40,7 @@ export function ProblemsPage() {
     staleTime: 1000 * 60 * 2,
   });
 
-  const problems = useMemo(() => (problemsResponse?.data as ProblemResponseDTO[]) || [], [problemsResponse?.data]);
+  const problems = useMemo(() => (problemsResponse?.data as PublicProblemResponseDTO[]) || [], [problemsResponse?.data]);
   const isLoading = isLoadingProblems || (isAuthenticated && isLoadingSubmissions);
 
   const userFinishedIds = useMemo(() => {
@@ -117,7 +117,7 @@ export function ProblemsPage() {
                   <Terminal className="text-primary mt-0.5 shrink-0" size={20} />
                   <div>
                     <h4 className="font-bold text-white">Desafios de Código</h4>
-                    <p className="text-gray-400 mt-1 leading-relaxed">Explore nossa biblioteca de problemas. Eles variam em dificuldade (EASY, MEDIUM, HARD) e pontuação.</p>
+                    <p className="text-gray-400 mt-1 leading-relaxed">Explore nossa biblioteca de problemas. Eles variam em dificuldade (EASY, MEDIUM, HARD) e no quanto valem agora.</p>
                   </div>
                 </div>
                 <div className="flex gap-4 items-start">
@@ -130,8 +130,13 @@ export function ProblemsPage() {
                 <div className="flex gap-4 items-start">
                   <Trophy className="text-primary mt-0.5 shrink-0" size={20} />
                   <div>
-                    <h4 className="font-bold text-white">Pontuação e Ranking</h4>
-                    <p className="text-gray-400 mt-1 leading-relaxed">Resolva os algoritmos, submeta o seu código e acumule pontos para subir posições no ranking geral da plataforma.</p>
+                    <h4 className="font-bold text-white">Corrida por Pontos</h4>
+                    <p className="text-gray-400 mt-1 leading-relaxed">
+                      O número no card é quanto o problema vale <strong className="text-white">agora</strong>: quem resolver
+                      primeiro leva mais. A cada aluno que acerta, o problema passa a valer menos, até parar num valor
+                      mínimo. Você fica com a pontuação do momento em que acertou, e ela não muda depois.
+                      Errar não custa pontos — pode tentar quantas vezes precisar. Cada desafio conta uma vez só.
+                    </p>
                   </div>
                 </div>
               </div>
@@ -241,11 +246,11 @@ export function ProblemsPage() {
                   <Trophy size={12} />
                   Mínimo de Pontos: <span className="text-primary">{minPoints}</span>
                 </div>
-                <input 
+                <input
                   type="range"
                   min="0"
-                  max="500"
-                  step="50"
+                  max="200"
+                  step="10"
                   value={minPoints}
                   onChange={(e) => setMinPoints(Number(e.target.value))}
                   className="w-full h-2 bg-white/10 rounded-lg appearance-none cursor-pointer accent-primary"

--- a/src/pages/ProblemsPage.tsx
+++ b/src/pages/ProblemsPage.tsx
@@ -16,6 +16,8 @@ import {
   Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger,
 } from "@/components/ui/dialog";
 
+const POINTS_SLIDER_STEP = 10;
+
 export function ProblemsPage() {
   const [, setSelectedProblem] = useState<PublicProblemResponseDTO | null>(null);
   const { user, isAuthenticated } = useAuth();
@@ -43,13 +45,31 @@ export function ProblemsPage() {
   const problems = useMemo(() => (problemsResponse?.data as PublicProblemResponseDTO[]) || [], [problemsResponse?.data]);
   const isLoading = isLoadingProblems || (isAuthenticated && isLoadingSubmissions);
 
-  const userFinishedIds = useMemo(() => {
-    if (!submissionsResponse?.data) return new Set<string>();
-    const finished = (submissionsResponse.data as SubmitResponseDTO[])
-      .filter(s => s.isFinished)
-      .map(s => s.problemId);
-    return new Set(finished as string[]);
-  }, [submissionsResponse?.data]);
+  // Mapa em vez de conjunto: o card do problema resolvido mostra os pontos que o
+  // aluno congelou no acerto, não o valor corrente.
+  const userEarnedByProblem = useMemo(
+    () =>
+      new Map<string, number>(
+        ((submissionsResponse?.data as SubmitResponseDTO[]) || [])
+          .filter(s => s.isFinished && s.problemId)
+          .map(s => [String(s.problemId), s.pointsEarned ?? 0])
+      ),
+    [submissionsResponse?.data]
+  );
+
+  // O teto do filtro sai do próprio catálogo: com um número fixo, um problema
+  // que valha mais do que ele fica fora do alcance do slider.
+  const pointsSliderMax = useMemo(() => {
+    const highest = problems.reduce((max, p) => Math.max(max, p.points || 0), 0);
+    return Math.max(
+      POINTS_SLIDER_STEP,
+      Math.ceil(highest / POINTS_SLIDER_STEP) * POINTS_SLIDER_STEP
+    );
+  }, [problems]);
+
+  // O catálogo pode encolher depois de o aluno arrastar o slider; sem o clamp,
+  // um mínimo acima do teto novo esconderia todos os problemas.
+  const effectiveMinPoints = Math.min(minPoints, pointsSliderMax);
 
   const filteredProblems = useMemo(() => {
     return problems.filter(p => {
@@ -57,13 +77,13 @@ export function ProblemsPage() {
       const id = p.id || "";
       const diff = p.difficulty || "MEDIUM";
       const pts = p.points || 0;
-      const isDone = userFinishedIds.has(id);
+      const isDone = userEarnedByProblem.has(id);
 
       const matchesName = title.toLowerCase().includes(nameFilter.toLowerCase());
       const matchesId = id.toLowerCase().includes(idFilter.toLowerCase()) || 
                         id.toLowerCase().includes(`#${idFilter.toLowerCase()}`);
       const matchesDifficulty = difficultyFilter === "ALL" || diff === difficultyFilter;
-      const matchesPoints = pts >= minPoints;
+      const matchesPoints = pts >= effectiveMinPoints;
       const matchesStatus = 
         statusFilter === "ALL" || 
         (statusFilter === "DONE" && isDone) || 
@@ -71,7 +91,7 @@ export function ProblemsPage() {
 
       return matchesName && matchesId && matchesDifficulty && matchesPoints && matchesStatus;
     });
-  }, [problems, nameFilter, idFilter, difficultyFilter, minPoints, statusFilter, userFinishedIds]);
+  }, [problems, nameFilter, idFilter, difficultyFilter, effectiveMinPoints, statusFilter, userEarnedByProblem]);
 
   const clearFilters = () => {
     setNameFilter("");
@@ -244,14 +264,14 @@ export function ProblemsPage() {
               <div className="space-y-3">
                 <div className="flex items-center gap-2 text-[10px] font-bold text-gray-500 uppercase tracking-widest ml-1">
                   <Trophy size={12} />
-                  Mínimo de Pontos: <span className="text-primary">{minPoints}</span>
+                  Mínimo de Pontos: <span className="text-primary">{effectiveMinPoints}</span>
                 </div>
                 <input
                   type="range"
-                  min="0"
-                  max="200"
-                  step="10"
-                  value={minPoints}
+                  min={0}
+                  max={pointsSliderMax}
+                  step={POINTS_SLIDER_STEP}
+                  value={effectiveMinPoints}
                   onChange={(e) => setMinPoints(Number(e.target.value))}
                   className="w-full h-2 bg-white/10 rounded-lg appearance-none cursor-pointer accent-primary"
                 />
@@ -298,7 +318,8 @@ export function ProblemsPage() {
                     <ProblemCard 
                       key={problem.id} 
                       problem={problem} 
-                      isFinished={userFinishedIds.has(problem.id || "")}
+                      isFinished={userEarnedByProblem.has(problem.id || "")}
+                      pointsEarned={userEarnedByProblem.get(problem.id || "")}
                       onClick={setSelectedProblem} 
                     />
                   ))}
@@ -320,7 +341,8 @@ export function ProblemsPage() {
                     <ProblemCard 
                       key={problem.id} 
                       problem={problem} 
-                      isFinished={userFinishedIds.has(problem.id || "")}
+                      isFinished={userEarnedByProblem.has(problem.id || "")}
+                      pointsEarned={userEarnedByProblem.get(problem.id || "")}
                       onClick={setSelectedProblem} 
                     />
                   ))}


### PR DESCRIPTION
## 🔗 Task no ClickUp

<!-- Informe aqui o ID da task relacionada no ClickUp -->

ID da Task:

## 📝 Descrição das mudanças

Metade do front do novo modelo de pontuação. A mãe é a back#15 (PR back#39, já mergeado em `ca239e8`) — **não há mudança de contrato aqui**, só consumo.

O `points` do problema agora **é o valor corrente**: quanto o próximo aluno a resolver leva. Ele cai `decrement` a cada aluno distinto que resolve, com piso em `floorPoints` e teto em `initialPoints`. Os três parâmetros só saem nas rotas admin.

- **SDK regerado** contra o back local na `main` (nunca contra produção, que ainda não recebeu o deploy).
- **`src/lib/problem-scoring.ts` (novo)**: dono único dos defaults (100/70/5) e da validação. Os dois formulários precisam da mesma regra, e o repo já teve o problema de cópias divergentes espalhadas pelas telas.
- **Admin**: criar e editar problema ganham valor inicial, piso e decremento. O valor corrente **sai do formulário** e passa a mudar só pelo botão "Reiniciar corrida" (com confirmação) — mandá-lo junto brigaria com o clamp do back. A coluna "Pontos" vira `corrente / inicial`, com piso e decremento no hover.
- **Aluno**: o badge continua `PONTOS` com um `?` que explica no hover que aquele é o valor de agora; quem já resolveu vê **os pontos que ele ganhou**, não o valor corrente. O submit passa a ramificar por **status** (nunca pela mensagem, que traz texto interno do back): 409 vira modal próprio de "já resolveu" e falha de rede deixa de ser mostrada como resposta errada.
- **Cache**: a tela do problema saiu de `useState`/`useEffect` para `useQuery`, reusando a chave `['submissions', user?.id]` da listagem, e invalida as duas depois do acerto.
- As telas públicas passaram a usar `PublicProblemResponseDTO`. O cast anterior para `ProblemResponseDTO` mentia sobre o payload — era exatamente o que deixaria alguém ler `initialPoints` numa tela de aluno.

## 🎯 Tipo de Mudança

- [ ] Bug fix (correção de bug)
- [x] New feature (nova funcionalidade)
- [ ] Documentation (documentação)
- [ ] Refactoring (refatoração)
- [ ] Test (testes)

## 📸 Evidências

Não há testes no projeto. Validação = `npm run lint` + `npm run build` + clique real (chromium do sistema via playwright-core) contra o back local na `main`, com banco descartável.

**Semente com valores cruzados** (números alinhados esconderiam um bug de "campo errado"):
`P1` = corrente 85 / inicial 100 / piso 70 / dec 5, resolvido pelo aluno valendo **100**; `P2` = 200/200/50/25; `P3` = 30/30/0/0.

| CA | Antes (na `main`) | Depois (neste branch) |
|---|---|---|
| CA1 form de criação | `#points` existe (valor `0`); `initialPoints/floorPoints/decrement` = `false/false/false` | `#initialPoints=100 #floorPoints=70 #decrement=5`; `#points` não existe mais. Criado via UI → `GET /problems/admin/all` devolve `{points: 100, initialPoints: 100, floorPoints: 70, decrement: 5}` (o `points` nasceu do `initialPoints`) |
| CA2 form de edição | diálogo mostra só "Pontuação"; sem botão de reiniciar | abre com `200 / 50 / 25`; piso → 60, guardar, reabrir → `inicial=200 piso=60 dec=25` |
| CA3 validação client | — | piso 500/inicial 100 → *"O piso não pode ser maior que o valor inicial."*; `-1` → *"não pode ser negativo"*; `1.5` → *"tem de ser um número inteiro"*. **Requests POST/PATCH disparadas: 0** |
| CA4 `?` no badge | `span[title]` no badge: `false` | badge `30 PONTOS ?`, `title` = *"Este é o valor de agora: o próximo aluno a resolver leva esses pontos, e o problema vale menos a cada aluno que resolve."* |
| CA5 já resolvido (409) | `"OPS, ESTÁ ERRADO... A resposta enviada não coincide com o output esperado."` | `"VOCÊ JÁ RESOLVEU ESTE PROBLEMA — Cada desafio conta uma vez só..."` |
| CA6 valor sem F5 | card de P2 fica em **200** enquanto o back já está em **175** | card vai a **175**; `recargas de página inteira: 1` (só a inicial — o cache foi preservado) |
| CA7 vazamento | — | `grep initialPoints\|floorPoints\|decrement` em `ProblemsPage`/`ProblemDetailsPage`/`components/problems/` → vazio |
| CA8 penalidade | — | `grep -rni penalidad src/` → vazio |
| CA11 reiniciar corrida | botão não existe | P1 `85 / 100` → cancelar → `85 / 100`; confirmar → `100 / 100` |
| CA12 pontos de quem resolveu | badge `EASY 85 PONTOS` (o valor atual, não o dele); "você ganhou" → `false` | `100 PONTOS QUE VOCÊ GANHOU` + *"Você ganhou 100 pontos neste desafio."*; o `85` não aparece na tela |
| CA13 "Como Funciona?" | *"Pontuação e Ranking — Resolva os algoritmos, submeta o seu código e acumule pontos..."* | *"Corrida por Pontos — O número no card é quanto o problema vale agora: quem resolver primeiro leva mais... Errar não custa pontos... Cada desafio conta uma vez só."* |
| CA14 falha de envio | rede caída → `"OPS, ESTÁ ERRADO..."` (mentira para o aluno) | `"FALHA AO ENVIAR — ... Isto não é um erro na resposta"`, tanto em rede caída quanto em 5xx. Resposta errada de verdade continua caindo no modal vermelho |
| CA15 coluna admin | `"85"`, sem `title` | `"85 / 100"`, `title` = `"Valor corrente: 85 • Inicial: 100 • Piso: 70 • Decremento: 5"` |
| CA16 slider | `min=0 max=500 step=50` | `min=0 max=200 step=10`; filtro 90 esconde P1 (85) e mantém P2 |

`npm run lint` e `npm run build` limpos.

## ✅ Checklist

- [x] Código segue os padrões do projeto
- [x] Self-review foi feito
- [x] Código foi testado localmente

## 📌 Notas adicionais

- **Pegadinha encontrada durante a validação, que vale para qualquer teste de cache no front:** verificar invalidação de query com `page.goto()` **não vale** — cada `goto` recarrega a SPA e zera o cache do TanStack Query, então o teste passa mesmo com a invalidação quebrada. O CA6 só reproduziu o "antes" (card preso em 200) quando o roteiro passou a navegar por clique, com uma carga de página só. Proponho registrar isso no `CLAUDE.md`.
- O ranking e o perfil aparecem zerados depois do deploy do back — é a migração destrutiva da back#15, não regressão do front.
- Fora de escopo (respostas do dono na spec): remoção de `mock-problems.ts` e `types/problem.types.ts` (dado morto pré-existente), responsividade da tela de problema (front#14) e banner de aviso do reset.

Closes #12
