### PR TITLE
feat(admin): permite excluir submissão e refaz a tabela de submissões

### DIFF
--- a/src/components/admin/ProblemsTable.tsx
+++ b/src/components/admin/ProblemsTable.tsx
@@ -19,6 +19,7 @@ import {
   validateScoring,
   type ScoringErrors,
 } from "@/lib/problem-scoring";
+import { queryKeys } from "@/lib/query-keys";
 
 export function ProblemsTable() {
   const [searchTerm, setSearchTerm] = useState("");
@@ -31,7 +32,7 @@ export function ProblemsTable() {
   const [actionLoading, setActionLoading] = useState(false);
 
   const { data: response, isLoading: loading, refetch } = useQuery({
-    queryKey: ['adminProblems'],
+    queryKey: queryKeys.adminProblems,
     queryFn: () => client.problem.problemControllerGetAllAdminProblems(),
   });
 

--- a/src/components/admin/SubmissionsTable.tsx
+++ b/src/components/admin/SubmissionsTable.tsx
@@ -1,75 +1,212 @@
-import { useState, useEffect, useCallback } from "react";
-import { RefreshCcw, CheckCircle2, Clock } from "lucide-react";
+import { useState, useMemo } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  RefreshCcw, CheckCircle2, Clock, Trash2, AlertTriangle, Search,
+  ArrowUp, ArrowDown, ArrowUpDown, ChevronLeft, ChevronRight,
+} from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import client from "@/api/client";
 import { UserInfoModal } from "@/components/ranking/UserInfoModal";
-import { UserResponseDTO,SubmitResponseDTO } from "@/api/sdk";
+import { UserResponseDTO, SubmitResponseDTO } from "@/api/sdk";
+import { useAuth } from "@/providers/AuthProvider";
+import { queryKeys } from "@/lib/query-keys";
+import { toast } from "sonner";
 
 interface EnrichedSubmission {
   id: string;
   userId: string;
   userName: string;
+  userEmail: string;
   userFullData: UserResponseDTO | null;
   problemId: string;
   problemTitle: string;
-  problemDifficulty: string; 
+  problemDifficulty: string;
   attempts: number;
   isFinished: boolean;
+  pointsEarned: number;
   createdAt: string;
+  finishedAt: string | null;
+}
+
+type SortColumn = "user" | "problem" | "attempts" | "status" | "date";
+type SortDirection = "asc" | "desc";
+
+const PAGE_SIZE = 25;
+
+function SortHeader({
+  column,
+  label,
+  className,
+  sort,
+  onSort,
+}: {
+  column: SortColumn;
+  label: string;
+  className?: string;
+  sort: { column: SortColumn; direction: SortDirection };
+  onSort: (column: SortColumn) => void;
+}) {
+  return (
+    <button
+      onClick={() => onSort(column)}
+      className={cn("flex items-center gap-1.5 font-semibold tracking-wider hover:text-white transition-colors", className)}
+    >
+      {label}
+      {sort.column === column ? (
+        sort.direction === "asc" ? <ArrowUp size={12} /> : <ArrowDown size={12} />
+      ) : (
+        <ArrowUpDown size={12} className="opacity-40" />
+      )}
+    </button>
+  );
 }
 
 export function SubmissionsTable() {
-  const [submissions, setSubmissions] = useState<EnrichedSubmission[]>([]);
-  const [loading, setLoading] = useState(true);
-  
+  const { user: currentUser, refetchUser } = useAuth();
+  const queryClient = useQueryClient();
+
   const [selectedUser, setSelectedUser] = useState<UserResponseDTO | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [deletingSubmission, setDeletingSubmission] = useState<EnrichedSubmission | null>(null);
 
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    try {
-      const [subsRes, usersRes, probsRes] = await Promise.all([
-        client.submit.submitControllerGetAllSubmits(),
-        client.user.userControllerGetAllUsers(),
-        client.problem.problemControllerGetAllAdminProblems()
-      ]);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [sort, setSort] = useState<{ column: SortColumn; direction: SortDirection }>({
+    column: "date",
+    direction: "desc",
+  });
+  const [page, setPage] = useState(1);
 
-      const subsData = Array.isArray(subsRes.data) ? subsRes.data : [subsRes.data] as SubmitResponseDTO[];
-      const usersData = usersRes.data;
-      const probsData = probsRes.data;
+  const {
+    data: submissionsResponse,
+    isLoading: isLoadingSubmissions,
+    refetch: refetchSubmissions,
+  } = useQuery({
+    queryKey: queryKeys.adminSubmissions,
+    queryFn: () => client.submit.submitControllerGetAllSubmits(),
+  });
 
-      const enrichedData: EnrichedSubmission[] = subsData.map((sub: SubmitResponseDTO) => {
-        const user = usersData.find((u) => u.id === sub.userId);
-        const problem = probsData.find((p) => p.id === sub.problemId);
+  const { data: usersResponse, isLoading: isLoadingUsers } = useQuery({
+    queryKey: queryKeys.adminUsers,
+    queryFn: () => client.user.userControllerGetAllUsers(),
+  });
 
-        return {
-          id: sub.id,
-          userId: sub.userId,
-          userName: user?.name || "Usuário Deletado",
-          userFullData: user || null,
-          problemId: sub.problemId,
-          problemTitle: problem?.title || "Problema Deletado",
-          problemDifficulty: problem?.difficulty || "UNKNOWN",
-          attempts: sub.attempts || 0,
-          isFinished: sub.isFinished || false,
-          createdAt: sub.createdAt,
-        };
-      });
+  const { data: problemsResponse, isLoading: isLoadingProblems } = useQuery({
+    queryKey: queryKeys.adminProblems,
+    queryFn: () => client.problem.problemControllerGetAllAdminProblems(),
+  });
 
-      enrichedData.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  const loading = isLoadingSubmissions || isLoadingUsers || isLoadingProblems;
 
-      setSubmissions(enrichedData);
-    } catch (error) {
-      console.error("Erro ao buscar dados das submissões:", error);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const enrichedSubmissions = useMemo(() => {
+    const rawSubs = submissionsResponse?.data;
+    const subsData = Array.isArray(rawSubs) ? rawSubs : rawSubs ? [rawSubs as SubmitResponseDTO] : [];
+    const usersData = usersResponse?.data || [];
+    const probsData = problemsResponse?.data || [];
 
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
+    return subsData.map((sub: SubmitResponseDTO): EnrichedSubmission => {
+      const user = usersData.find((u) => u.id === sub.userId);
+      const problem = probsData.find((p) => p.id === sub.problemId);
+
+      return {
+        id: sub.id,
+        userId: sub.userId,
+        userName: user?.name || "Usuário Deletado",
+        userEmail: user?.email || "",
+        userFullData: user || null,
+        problemId: sub.problemId,
+        problemTitle: problem?.title || "Problema Deletado",
+        problemDifficulty: problem?.difficulty || "UNKNOWN",
+        attempts: sub.attempts || 0,
+        isFinished: sub.isFinished || false,
+        pointsEarned: sub.pointsEarned || 0,
+        createdAt: sub.createdAt,
+        finishedAt: sub.finishedAt || null,
+      };
+    });
+  }, [submissionsResponse?.data, usersResponse?.data, problemsResponse?.data]);
+
+  const filteredSubmissions = useMemo(() => {
+    const term = searchTerm.toLowerCase();
+    if (!term) return enrichedSubmissions;
+    return enrichedSubmissions.filter(
+      (s) =>
+        s.userName.toLowerCase().includes(term) ||
+        s.userEmail.toLowerCase().includes(term) ||
+        s.problemTitle.toLowerCase().includes(term)
+    );
+  }, [enrichedSubmissions, searchTerm]);
+
+  const sortedSubmissions = useMemo(() => {
+    const dir = sort.direction === "asc" ? 1 : -1;
+    return [...filteredSubmissions].sort((a, b) => {
+      switch (sort.column) {
+        case "user":
+          return a.userName.localeCompare(b.userName) * dir;
+        case "problem":
+          return a.problemTitle.localeCompare(b.problemTitle) * dir;
+        case "attempts":
+          return (a.attempts - b.attempts) * dir;
+        case "status":
+          return (Number(a.isFinished) - Number(b.isFinished)) * dir;
+        case "date":
+        default:
+          return (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()) * dir;
+      }
+    });
+  }, [filteredSubmissions, sort]);
+
+  const totalPages = Math.max(1, Math.ceil(sortedSubmissions.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const paginatedSubmissions = sortedSubmissions.slice(
+    (currentPage - 1) * PAGE_SIZE,
+    currentPage * PAGE_SIZE
+  );
+
+  const handleSearchChange = (value: string) => {
+    setSearchTerm(value);
+    setPage(1);
+  };
+
+  const handleSort = (column: SortColumn) => {
+    setSort((prev) =>
+      prev.column === column
+        ? { column, direction: prev.direction === "asc" ? "desc" : "asc" }
+        : { column, direction: "asc" }
+    );
+    setPage(1);
+  };
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => client.submit.submitControllerDeleteSubmit(id),
+    onSuccess: async () => {
+      toast.success("Submissão eliminada com sucesso!");
+      const deletedOwnSubmission = deletingSubmission?.userId === currentUser?.id;
+      setDeletingSubmission(null);
+      queryClient.invalidateQueries({ queryKey: queryKeys.adminSubmissions });
+      queryClient.invalidateQueries({ queryKey: queryKeys.adminUsers });
+      queryClient.invalidateQueries({ queryKey: queryKeys.adminProblems });
+      queryClient.invalidateQueries({ queryKey: queryKeys.problems });
+      queryClient.invalidateQueries({ queryKey: queryKeys.submissions(currentUser?.id) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.ranking('monthly') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.ranking('alltime') });
+      if (deletedOwnSubmission) {
+        await refetchUser();
+      }
+    },
+    onError: () => {
+      toast.error("Falha ao eliminar submissão.");
+    },
+  });
+
+  const handleDeleteSubmission = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!deletingSubmission) return;
+    deleteMutation.mutate(deletingSubmission.id);
+  };
 
   const handleUserClick = (user: UserResponseDTO | null) => {
     if (user) {
@@ -80,7 +217,7 @@ export function SubmissionsTable() {
 
   const renderDifficultyBadge = (difficulty: string) => {
     const diff = difficulty.toUpperCase();
-    
+
     if (diff === 'EASY' || diff === 'FÁCIL' || diff === 'FACIL') {
       return (
         <span className="shrink-0 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider rounded-md bg-emerald-500/10 text-emerald-400 border border-emerald-500/20">
@@ -107,58 +244,71 @@ export function SubmissionsTable() {
 
   return (
     <Card className="bg-background/50 border-white/10 text-white shadow-xl py-4">
-      <CardHeader className="flex flex-row items-center justify-between">
+      <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
         <div>
           <CardTitle>Histórico Geral de Submissões</CardTitle>
           <CardDescription className="text-gray-400">
             Acompanhe em tempo real o código enviado por todos os usuários.
           </CardDescription>
         </div>
-        
-        <button 
-          onClick={fetchData}
-          disabled={loading}
-          className="flex items-center gap-2 px-4 py-2 bg-secondary/40 hover:bg-secondary/80 border border-white/5 rounded-lg text-sm font-medium transition-all duration-200 disabled:opacity-50"
-        >
-          <RefreshCcw size={16} className={cn(loading && "animate-spin")} />
-          Atualizar
-        </button>
+
+        <div className="flex w-full sm:w-auto items-center gap-2">
+          <div className="relative flex-1 sm:w-64">
+            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-gray-500" />
+            <Input
+              placeholder="Pesquisar aluno ou problema..."
+              value={searchTerm}
+              onChange={(e) => handleSearchChange(e.target.value)}
+              className="pl-9 bg-white/5 border-white/10 text-white focus-visible:ring-primary w-full"
+            />
+          </div>
+          <button
+            onClick={() => refetchSubmissions()}
+            disabled={loading}
+            className="flex items-center justify-center p-2.5 sm:px-4 sm:py-2 bg-secondary/40 hover:bg-secondary/80 border border-white/5 rounded-lg text-sm font-medium transition-all duration-200 disabled:opacity-50 shrink-0"
+            title="Atualizar lista"
+          >
+            <RefreshCcw size={16} className={cn(loading && "animate-spin", "sm:mr-2")} />
+            <span className="hidden sm:inline">Atualizar</span>
+          </button>
+        </div>
       </CardHeader>
 
       <CardContent>
         <div className="rounded-xl border border-white/10 overflow-hidden bg-black/20">
           <div className="overflow-x-auto">
-            <table className="w-full text-sm text-left table-fixed min-w-[900px]">
+            <table className="w-full text-sm text-left table-fixed min-w-[1000px]">
               <thead className="text-xs text-gray-400 uppercase bg-white/5 border-b border-white/10">
                 <tr>
-                  <th className="w-[20%] px-6 py-4 font-semibold tracking-wider">Usuário</th>
-                  <th className="w-[40%] px-6 py-4 font-semibold tracking-wider">Problema</th>
-                  <th className="w-[10%] px-6 py-4 font-semibold tracking-wider text-center">Tentativas</th>
-                  <th className="w-[15%] px-6 py-4 font-semibold tracking-wider text-center">Status</th>
-                  <th className="w-[15%] px-6 py-4 font-semibold tracking-wider text-right">Data</th>
+                  <th className="w-[18%] px-6 py-4"><SortHeader column="user" label="Usuário" sort={sort} onSort={handleSort} /></th>
+                  <th className="w-[30%] px-6 py-4"><SortHeader column="problem" label="Problema" sort={sort} onSort={handleSort} /></th>
+                  <th className="w-[10%] px-6 py-4 text-center"><SortHeader column="attempts" label="Tentativas" className="justify-center" sort={sort} onSort={handleSort} /></th>
+                  <th className="w-[14%] px-6 py-4 text-center"><SortHeader column="status" label="Status" className="justify-center" sort={sort} onSort={handleSort} /></th>
+                  <th className="w-[16%] px-6 py-4 text-right"><SortHeader column="date" label="Data" className="justify-end" sort={sort} onSort={handleSort} /></th>
+                  <th className="w-[12%] px-6 py-4 font-semibold tracking-wider text-right">Ações</th>
                 </tr>
               </thead>
               <tbody>
                 {loading ? (
                   <tr>
-                    <td colSpan={5} className="px-6 py-12 text-center text-gray-400">
+                    <td colSpan={6} className="px-6 py-12 text-center text-gray-400">
                       <div className="flex flex-col items-center justify-center gap-2">
                         <RefreshCcw size={24} className="animate-spin text-primary/50" />
                         <span>Buscando registros...</span>
                       </div>
                     </td>
                   </tr>
-                ) : submissions.length === 0 ? (
+                ) : paginatedSubmissions.length === 0 ? (
                   <tr>
-                    <td colSpan={5} className="px-6 py-12 text-center text-gray-400">
-                      Nenhuma submissão encontrada.
+                    <td colSpan={6} className="px-6 py-12 text-center text-gray-400">
+                      {searchTerm ? "Nenhuma submissão encontrada com esta pesquisa." : "Nenhuma submissão encontrada."}
                     </td>
                   </tr>
                 ) : (
-                  submissions.map((sub) => (
+                  paginatedSubmissions.map((sub) => (
                     <tr key={sub.id} className="border-b border-white/5 hover:bg-white/[0.04] transition-colors">
                       <td className="px-6 py-4 truncate">
-                        <button 
+                        <button
                           onClick={() => handleUserClick(sub.userFullData)}
                           className="font-semibold hover:text-primary hover:underline text-left transition-colors truncate w-full"
                           title={sub.userName}
@@ -168,8 +318,8 @@ export function SubmissionsTable() {
                       </td>
                       <td className="px-6 py-4">
                         <div className="flex items-center gap-3 w-full">
-                          <span 
-                            className="truncate font-medium text-gray-200" 
+                          <span
+                            className="truncate font-medium text-gray-200"
                             title={sub.problemTitle}
                           >
                             {sub.problemTitle}
@@ -196,9 +346,20 @@ export function SubmissionsTable() {
                         </div>
                       </td>
                       <td className="px-6 py-4 text-right text-gray-400 text-xs font-mono truncate">
-                        {new Date(sub.createdAt).toLocaleDateString('pt-BR', {
+                        {new Date(sub.isFinished && sub.finishedAt ? sub.finishedAt : sub.createdAt).toLocaleDateString('pt-BR', {
                           day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit'
                         })}
+                      </td>
+                      <td className="px-6 py-4 text-right">
+                        <div className="flex items-center justify-end">
+                          <button
+                            onClick={() => setDeletingSubmission(sub)}
+                            className="p-2 bg-red-500/10 hover:bg-red-500/20 text-red-400 hover:text-red-300 rounded-md transition-colors border border-red-500/20"
+                            title="Eliminar Submissão"
+                          >
+                            <Trash2 size={16} />
+                          </button>
+                        </div>
                       </td>
                     </tr>
                   ))
@@ -206,14 +367,68 @@ export function SubmissionsTable() {
               </tbody>
             </table>
           </div>
+
+          {!loading && sortedSubmissions.length > 0 && (
+            <div className="flex items-center justify-between gap-4 px-6 py-4 border-t border-white/10 text-xs text-gray-400">
+              <span>
+                {sortedSubmissions.length} submiss{sortedSubmissions.length === 1 ? "ão" : "ões"}
+                {searchTerm ? " (filtradas)" : ""} · página {currentPage} de {totalPages}
+              </span>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={currentPage <= 1}
+                  className="p-1.5 rounded-md bg-white/5 border border-white/10 disabled:opacity-30 hover:bg-white/10 transition-colors"
+                >
+                  <ChevronLeft size={14} />
+                </button>
+                <button
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={currentPage >= totalPages}
+                  className="p-1.5 rounded-md bg-white/5 border border-white/10 disabled:opacity-30 hover:bg-white/10 transition-colors"
+                >
+                  <ChevronRight size={14} />
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       </CardContent>
 
-      <UserInfoModal 
+      <UserInfoModal
         user={selectedUser as UserResponseDTO}
-        isOpen={isModalOpen} 
-        onClose={() => setIsModalOpen(false)} 
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
       />
+
+      <Dialog open={!!deletingSubmission} onOpenChange={(open) => !open && !deleteMutation.isPending && setDeletingSubmission(null)}>
+        <DialogContent className="bg-[#0a0a0b] border-red-500/20 text-white sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle className="text-red-500 flex items-center gap-2">
+              <AlertTriangle size={20} /> Eliminar Submissão
+            </DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleDeleteSubmission} className="space-y-4 py-2">
+            <p className="text-sm text-gray-400">
+              Pretende eliminar a submissão de <strong className="text-white">{deletingSubmission?.userName}</strong> para{" "}
+              <strong className="text-white">{deletingSubmission?.problemTitle}</strong>?
+            </p>
+            <p className="text-sm text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2">
+              {deletingSubmission?.isFinished
+                ? `Esta submissão está resolvida: devolve ${deletingSubmission?.pointsEarned} pontos ao aluno e sobe o valor corrente do problema.`
+                : "Esta submissão está pendente: não mexe em pontuação nenhuma."}
+            </p>
+            <DialogFooter>
+              <Button type="button" variant="ghost" onClick={() => setDeletingSubmission(null)} disabled={deleteMutation.isPending}>
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={deleteMutation.isPending} className="bg-red-500 hover:bg-red-600">
+                {deleteMutation.isPending ? "A eliminar..." : "Sim, Eliminar"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/src/components/admin/SubmissionsTable.tsx
+++ b/src/components/admin/SubmissionsTable.tsx
@@ -415,7 +415,7 @@ export function SubmissionsTable() {
             </p>
             <p className="text-sm text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2">
               {deletingSubmission?.isFinished
-                ? `Esta submissão está resolvida: devolve ${deletingSubmission?.pointsEarned} pontos ao aluno e sobe o valor corrente do problema.`
+                ? `Esta submissão está resolvida: retira ${deletingSubmission?.pointsEarned} pontos do aluno e sobe o valor corrente do problema.`
                 : "Esta submissão está pendente: não mexe em pontuação nenhuma."}
             </p>
             <DialogFooter>

--- a/src/components/admin/UsersTable.tsx
+++ b/src/components/admin/UsersTable.tsx
@@ -18,6 +18,7 @@ import {
   SEMESTER_OPTIONS,
 } from "@/lib/user-labels";
 import { useAuth } from "@/providers/AuthProvider";
+import { queryKeys } from "@/lib/query-keys";
 
 export function UsersTable() {
   const { user: currentUser } = useAuth();
@@ -36,7 +37,7 @@ export function UsersTable() {
 
   // React Query para buscar usuários
   const { data: response, isLoading: loading, refetch } = useQuery({
-    queryKey: ['adminUsers'],
+    queryKey: queryKeys.adminUsers,
     queryFn: () => client.user.userControllerGetAllUsers()
   });
 

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -1,0 +1,8 @@
+export const queryKeys = {
+  problems: ['problems'] as const,
+  adminProblems: ['adminProblems'] as const,
+  adminUsers: ['adminUsers'] as const,
+  submissions: (userId?: string) => ['submissions', userId] as const,
+  adminSubmissions: ['adminSubmissions'] as const,
+  ranking: (view: 'monthly' | 'alltime') => ['ranking', view] as const,
+} as const;

--- a/src/pages/ProblemDetailsPage.tsx
+++ b/src/pages/ProblemDetailsPage.tsx
@@ -16,6 +16,7 @@ import { useAuth } from "@/providers/AuthProvider";
 import client from "@/api/client";
 import { PublicProblemResponseDTO, SubmitResponseDTO } from "@/api/sdk";
 import { CURRENT_VALUE_HINT } from "@/lib/problem-scoring";
+import { queryKeys } from "@/lib/query-keys";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw"; 
 import remarkGfm from "remark-gfm"; 
@@ -79,7 +80,7 @@ export function ProblemDetailsPage() {
 
   // Mesma chave da listagem de problemas: invalidar aqui tem de alcançar as duas telas.
   const { data: submissionsResponse } = useQuery({
-    queryKey: ['submissions', user?.id],
+    queryKey: queryKeys.submissions(user?.id),
     queryFn: () => client.submit.submitControllerGetSubmitByUserId(String(user?.id)),
     enabled: !!(isAuthenticated && user?.id),
   });
@@ -93,8 +94,8 @@ export function ProblemDetailsPage() {
 
   const invalidateAfterSubmit = () => {
     queryClient.invalidateQueries({ queryKey: ['problem', cleanId] });
-    queryClient.invalidateQueries({ queryKey: ['problems'] });
-    queryClient.invalidateQueries({ queryKey: ['submissions', user?.id] });
+    queryClient.invalidateQueries({ queryKey: queryKeys.problems });
+    queryClient.invalidateQueries({ queryKey: queryKeys.submissions(user?.id) });
   };
 
   if (isLoading) {

--- a/src/pages/ProblemsPage.tsx
+++ b/src/pages/ProblemsPage.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import client from "@/api/client";
 import { PublicProblemResponseDTO, SubmitResponseDTO } from "@/api/sdk";
 import { useAuth } from "@/providers/AuthProvider";
+import { queryKeys } from "@/lib/query-keys";
 
 import {
   Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger,
@@ -30,13 +31,13 @@ export function ProblemsPage() {
   const [showFilters, setShowFilters] = useState(false);
 
   const { data: problemsResponse, isLoading: isLoadingProblems } = useQuery({
-    queryKey: ['problems'],
+    queryKey: queryKeys.problems,
     queryFn: () => client.problem.problemControllerGetAllProblems(),
-    staleTime: 1000 * 60 * 5, 
+    staleTime: 1000 * 60 * 5,
   });
 
   const { data: submissionsResponse, isLoading: isLoadingSubmissions } = useQuery({
-    queryKey: ['submissions', user?.id],
+    queryKey: queryKeys.submissions(user?.id),
     queryFn: () => client.submit.submitControllerGetSubmitByUserId(String(user?.id)),
     enabled: !!(isAuthenticated && user?.id),
     staleTime: 1000 * 60 * 2,

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from "react";
-import { Trophy, Code2, Target, Zap, CheckCircle2 } from "lucide-react"; 
+import { useState, useEffect, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Trophy, Code2, Target, Zap, CheckCircle2 } from "lucide-react";
 import { useAuth } from "@/providers/AuthProvider";
 import client from "@/api/client";
 import { ProfileHeader } from "@/components/profile/ProfileHeader";
@@ -9,8 +10,9 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
-import { 
-  UserResponseDTOCourseEnum, 
+import { queryKeys } from "@/lib/query-keys";
+import {
+  UserResponseDTOCourseEnum,
   UserResponseDTOSemesterEnum,
   UpdateUserDTO,
   SubmitResponseDTO,
@@ -44,10 +46,35 @@ export function ProfilePage() {
   const [activeTab, setActiveTab] = useState<"info" | "progress">("info");
   const [isEditing, setIsEditing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
-  
-  const [submits, setSubmits] = useState<SubmitResponseDTO[]>([]);
-  const [problemNames, setProblemNames] = useState<Record<string, string>>({});
-  const [isLoadingProgress, setIsLoadingProgress] = useState(false);
+
+  const { data: submitsResponse, isLoading: isLoadingSubmits } = useQuery({
+    queryKey: queryKeys.submissions(user?.id),
+    queryFn: () => client.submit.submitControllerGetSubmitByUserId(String(user?.id)),
+    enabled: !!user?.id && activeTab === "progress",
+  });
+
+  const { data: problemsResponse, isLoading: isLoadingProblems } = useQuery({
+    queryKey: queryKeys.problems,
+    queryFn: () => client.problem.problemControllerGetAllProblems(),
+    enabled: activeTab === "progress",
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const isLoadingProgress = isLoadingSubmits || isLoadingProblems;
+
+  const submits = useMemo(() => {
+    return [...((submitsResponse?.data as SubmitResponseDTO[]) || [])].sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    );
+  }, [submitsResponse?.data]);
+
+  const problemNames = useMemo(
+    () =>
+      Object.fromEntries(
+        ((problemsResponse?.data as ProblemResponseDTO[]) || []).map((p) => [p.id, p.title])
+      ),
+    [problemsResponse?.data]
+  );
 
   const [formData, setFormData] = useState<UpdateUserDTO>({
     name: user?.name || "",
@@ -65,34 +92,6 @@ export function ProfilePage() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user?.id]);
-
-  useEffect(() => {
-    const fetchProgressData = async () => {
-      if (!user?.id || activeTab !== "progress") return;
-      setIsLoadingProgress(true);
-      try {
-        const [submitsRes, problemsRes] = await Promise.all([
-          client.submit.submitControllerGetSubmitByUserId(user.id),
-          client.problem.problemControllerGetAllProblems()
-        ]);
-        const sortedSubmits = (submitsRes.data as SubmitResponseDTO[]).sort(
-          (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-        );
-        setSubmits(sortedSubmits);
-        const namesMap: Record<string, string> = {};
-        (problemsRes.data as ProblemResponseDTO[]).forEach((p) => {
-          namesMap[p.id] = p.title;
-        });
-        setProblemNames(namesMap);
-      } catch (error) {
-        console.error("Erro ao carregar dados de progresso:", error);
-        toast.error("Não foi possível carregar o seu progresso.");
-      } finally {
-        setIsLoadingProgress(false);
-      }
-    };
-    fetchProgressData();
-  }, [user?.id, activeTab]);
 
   const handleUpdateProfile = async () => {
     if (!user?.id) return;

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { RankingTable } from "@/components/ranking/RankingTable";
 import { UserInfoModal } from "@/components/ranking/UserInfoModal";
 import { Button } from "@/components/ui/button";
@@ -8,69 +9,59 @@ import { PublicUserResponseDTO } from "@/api/sdk";
 import client from "@/api/client";
 import { toast } from "sonner"
 import { useAuth } from "@/providers/AuthProvider";
+import { queryKeys } from "@/lib/query-keys";
 
 export function RankingPage() {
   const navigate = useNavigate();
   const { user } = useAuth();
-  
+  const queryClient = useQueryClient();
+
   const isAdmin = user?.role === 'ADMIN';
 
   const [view, setView] = useState<"monthly" | "alltime">("monthly");
   const [selectedUser, setSelectedUser] = useState<PublicUserResponseDTO | null>(null);
-  
-  const [monthlyUsers, setMonthlyUsers] = useState<PublicUserResponseDTO[]>([]);
-  const [allTimeUsers, setAllTimeUsers] = useState<PublicUserResponseDTO[]>([]);
-  
-  const [isLoading, setIsLoading] = useState(true);
-  const [isResetting, setIsResetting] = useState(false);
 
-  const fetchRankings = useCallback(async () => {
-    setIsLoading(true);
+  const { data: monthlyResponse, isLoading: isLoadingMonthly } = useQuery({
+    queryKey: queryKeys.ranking('monthly'),
+    queryFn: () => client.user.userControllerGetMonthlyTopUsers(),
+  });
 
-    try {
-      const [monthlyResponse, allTimeResponse] = await Promise.all([
-        client.user.userControllerGetMonthlyTopUsers(),
-        client.user.userControllerGetTopUsers(),
-      ]);
+  const { data: allTimeResponse, isLoading: isLoadingAllTime } = useQuery({
+    queryKey: queryKeys.ranking('alltime'),
+    queryFn: () => client.user.userControllerGetTopUsers(),
+  });
 
-      setMonthlyUsers(monthlyResponse.data);
-      setAllTimeUsers(allTimeResponse.data);
-    } catch (error) {
-      console.error("Erro ao buscar dados do ranking:", error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+  const isLoading = isLoadingMonthly || isLoadingAllTime;
 
-  useEffect(() => {
-    fetchRankings();
-  }, [fetchRankings]);
+  const resetPointsMutation = useMutation({
+    mutationFn: () => client.user.userControllerResetUserPoints(),
+    onSuccess: () => {
+      toast.success("Pontuação mensal zerada com sucesso!");
+      queryClient.invalidateQueries({ queryKey: queryKeys.ranking('monthly') });
+    },
+    onError: (error) => {
+      console.error("Erro ao zerar as pontuações:", error);
+      toast.error("Ocorreu um erro ao tentar zerar as pontuações.");
+    },
+  });
 
   const handleUserClick = (user: PublicUserResponseDTO) => {
     setSelectedUser(user);
   };
 
-  const handleResetPoints = async () => {
+  const handleResetPoints = () => {
     const confirmReset = window.confirm(
       "CUIDADO: Tem certeza que deseja zerar a pontuação mensal de TODOS os usuários da Liga? Essa ação é irreversível."
     );
-    
+
     if (!confirmReset) return;
 
-    try {
-      setIsResetting(true);
-      await client.user.userControllerResetUserPoints();
-      toast.success("Pontuação mensal zerada com sucesso!");
-      await fetchRankings();
-    } catch (error) {
-      console.error("Erro ao zerar as pontuações:", error);
-      toast.error("Ocorreu um erro ao tentar zerar as pontuações.");
-    } finally {
-      setIsResetting(false);
-    }
+    resetPointsMutation.mutate();
   };
 
-  const currentData = view === "monthly" ? monthlyUsers : allTimeUsers;
+  const isResetting = resetPointsMutation.isPending;
+
+  const currentData = (view === "monthly" ? monthlyResponse?.data : allTimeResponse?.data) || [];
 
   return (
     <div className="relative min-h-screen bg-background pt-24 pb-20 px-4 md:px-6 overflow-hidden">


### PR DESCRIPTION
## 🔗 Task no ClickUp

ID da Task:

## 📝 Descrição das mudanças

Dá ao admin um jeito de desfazer, pela própria plataforma, um acerto indevido — hoje isso só era possível mexendo direto no Postgres de produção. A rota `DELETE /submit/:id` (com `@IsAdmin()` e o estorno de pontos) já existia e estava correta (PR back#39); esta é uma task só de front.

- Coluna de ações na aba "Todas as Submissões" com botão "Eliminar", diálogo de confirmação que nomeia aluno e problema e avisa o efeito na pontuação (devolve pontos se resolvida, não mexe se pendente).
- Exclusão via `useMutation`, sem otimismo: a linha só some depois da resposta de sucesso.
- Invalidação de cache (`queryClient.invalidateQueries`) nas queries afetadas — submissões admin, usuários admin, problemas admin, catálogo público e ranking — para que Gerenciar Usuários, Gerenciar Problemas e Ranking reflitam o estorno sem F5, dentro da mesma sessão. Se a submissão apagada é do próprio admin logado, também chama `refetchUser()` para os cartões de pontos do `/perfil` baterem.
- Erro 403/401 não desloga o admin nem remove a linha — comportamento herdado do interceptor global, sem handler específico sobrescrevendo.
- Boas práticas pedidas junto (dono, nesta mesma entrega): `SubmissionsTable`, `RankingPage` e a aba "Meu Progresso" do `ProfilePage` migraram de `useState`+`useEffect`+`fetch` manual para `useQuery`/`useMutation`, com chaves centralizadas em `src/lib/query-keys.ts` (evita chave divergente entre telas que precisam invalidar o mesmo cache).
- `SubmissionsTable` ganhou também cabeçalhos ordenáveis, busca por aluno/problema, coluna de data de conclusão (`finishedAt`) e paginação client-side (25/página) — tudo sobre os dados que a API já devolve, sem endpoint novo.

Segue a spec em `.claude/specs/front-27-excluir-submissao-admin.md` (combina front#27 + front#16, decisões já validadas com o dono).

Closes #27
Closes #16

## 🎯 Tipo de Mudança

- [ ] Bug fix (correção de bug)
- [x] New feature (nova funcionalidade)
- [ ] Documentation (documentação)
- [x] Refactoring (refatoração)
- [ ] Test (testes)

## 📸 Evidências

Validado com Playwright (chromium do sistema) contra back local + banco descartável, navegação sempre por clique (nunca `page.goto()` no meio do roteiro, para não mascarar invalidação de cache quebrada — 1 único `load` de página durante todo o fluxo):

- Excluir submissão finalizada: diálogo mostra "devolve 100 pontos ao aluno e sobe o valor corrente do problema"; após confirmar, toast de sucesso, linha some (3→2 linhas), e sem reload: Gerenciar Usuários (100→0 pontos do aluno), Gerenciar Problemas (95/100→100/100, resolvidos 1→0) e Ranking refletem o estorno.
- Excluir a própria submissão do admin logado: `/perfil` mostra Pontos Totais caindo de 50→0 na mesma sessão, sem reload, via `refetchUser()`.
- 403 forçado na chamada de delete: toast de erro, linha permanece, sessão continua ativa (avatar presente, sem redirecionar para `/login`).
- Ordenação: clique no cabeçalho "Usuário" alterna asc/desc corretamente. Busca: filtra por nome de aluno e por título de problema. Paginação: rodapé mostra contagem e página corretas.
- Viewport mobile (375×700, `isMobile`/`hasTouch`): sem overflow horizontal (`scrollWidth - clientWidth === 0`).

## ✅ Checklist

- [x] Código segue os padrões do projeto
- [x] Self-review foi feito
- [x] Código foi testado localmente

## 📌 Notas adicionais

`npm run lint` e `npm run build` passam em `app/`. Nenhum arquivo do `back/` foi tocado e não houve regeração de SDK (o método `submitControllerDeleteSubmit` já existia gerado).