### PR TITLE
fix(problema): altura do banner acompanha a proporção real da imagem

### DIFF
--- a/src/pages/ProblemDetailsPage.tsx
+++ b/src/pages/ProblemDetailsPage.tsx
@@ -181,7 +181,7 @@ export function ProblemDetailsPage() {
       
       <div className="flex-1 flex flex-col border-r border-white/5 overflow-hidden">
         
-        <div className={cn("relative w-full overflow-hidden shrink-0", !problem.bannerUrl && "h-60")}>
+        <div className={cn("relative w-full overflow-hidden shrink-0", problem.bannerUrl ? "min-h-60" : "h-60")}>
           <Link to="/problemas" className="absolute top-6 left-6 z-30">
             <Button variant="ghost" size="icon" className="bg-black/50 hover:bg-black/80 rounded-full">
               <ArrowLeft size={20} />

--- a/src/pages/ProblemDetailsPage.tsx
+++ b/src/pages/ProblemDetailsPage.tsx
@@ -181,16 +181,16 @@ export function ProblemDetailsPage() {
       
       <div className="flex-1 flex flex-col border-r border-white/5 overflow-hidden">
         
-        <div className="relative h-60 w-full overflow-hidden shrink-0">
+        <div className={cn("relative w-full overflow-hidden shrink-0", !problem.bannerUrl && "h-60")}>
           <Link to="/problemas" className="absolute top-6 left-6 z-30">
             <Button variant="ghost" size="icon" className="bg-black/50 hover:bg-black/80 rounded-full">
               <ArrowLeft size={20} />
             </Button>
           </Link>
-          
+
           <div className="absolute inset-0 bg-gradient-to-br from-primary/30 via-purple-900/20 to-transparent z-0" />
           {problem.bannerUrl && (
-            <img src={problem.bannerUrl} alt={problem.title} className="h-full w-full object-cover mix-blend-overlay opacity-90" />
+            <img src={problem.bannerUrl} alt={problem.title} className="w-full h-auto max-h-80 lg:max-h-125 object-cover mix-blend-overlay opacity-90" />
           )}
           <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0b] via-transparent to-transparent z-10" />
           


### PR DESCRIPTION
## Resumo
- Banner da página de detalhe do problema (`ProblemDetailsPage.tsx`) deixa de ter altura fixa de 240px (`h-60`) quando há `bannerUrl` — passa a acompanhar a proporção real da imagem, com teto de **320px em mobile** e **500px em desktop** (`lg`, ≥1024px).
- Sem `bannerUrl`, a faixa mantém os 240px fixos atuais (fallback inalterado).
- Implementação CSS-only: `w-full h-auto max-h-80 lg:max-h-125 object-cover` no `<img>` — o `object-cover` garante que o `max-height` corte verticalmente (sem reduzir largura) só quando a proporção estoura o teto; abaixo do teto, a imagem aparece inteira.

## Antes / Depois
Testado com Playwright (`chromium` do sistema) contra um back local com banco descartável, dois problemas seedados com banners de proporção diferente (1600×400 largo e 1000×1000 quadrado) e um problema sem banner — sem tocar em produção.

**Antes** (`h-60` fixo, sem breakpoint): banner sempre 240px, imagem quadrada cortada agressivamente mesmo em desktop.

**Depois** (medido via `getBoundingClientRect`):
| Cenário | Largura viewport | Altura da faixa | Corte? |
|---|---|---|---|
| Banner largo (1600×400), desktop | 1440 | 259.75px | não, imagem inteira |
| Banner quadrado (1000×1000), desktop | 1440 | 500px (teto) | sim, só vertical |
| Sem banner, desktop | 1440 | 240px | fallback preservado |
| Banner largo (1600×400), mobile | 390 | 97.25px | não, imagem inteira |
| Banner quadrado (1000×1000), mobile | 390 | 320px (teto) | sim, só vertical |

Em todos os cenários os dois gradientes de overlay (`absolute inset-0`) cobrem 100% da área do wrapper (`overlaysCoverFully: true`), e a imagem fica centralizada horizontalmente (largura sempre 100%, sem faixas vazias nas laterais).

## Regressão front#14
O campo de resposta (input + botão "Enviar Resposta") vive na coluna direita (sidebar independente, com seu próprio `overflow-y-auto`), não na coluna do banner — por isso a posição do botão de envio é **idêntica pixel a pixel antes e depois** da mudança (`top: 686, bottom: 742` em viewport 375×667), confirmado revertendo a mudança temporariamente e comparando.

Achado à parte (pré-existente, fora do escopo desta issue): em qualquer viewport mobile testado (375×667 e 390×844), a coluna esquerda inteira (banner + instruções) colapsa para altura 0 por causa do layout flex — a coluna esquerda é `flex-1` (flex-basis 0%) competindo com a barra lateral direita, que é `h-full shrink-0`. Confirmado que esse colapso é **idêntico byte a byte antes e depois** desta mudança (não é uma regressão introduzida aqui), mas é mais abrangente do que o front#14 documentado (que fala só do campo de resposta) — vale abrir uma issue nova para isso.

## Validação
- `npm run lint` — sem erros.
- `npm run build` (`tsc -b && vite build`) — sem erros.
- Smoke test manual via Playwright cobrindo os 9 passos da spec: desktop/mobile × banner largo/quadrado/sem banner, overlays, e regressão front#14.
- Sem mudança de contrato de API — não foi necessário regenerar o SDK.

Closes #30