### PR TITLE
feat(problema): scroll unificado, painel de resposta retrátil e scrollbar estilizada

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -179,3 +179,24 @@
     letter-spacing: var(--tracking-normal);
   }
 }
+
+@layer utilities {
+  .custom-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: var(--primary) transparent;
+  }
+  .custom-scrollbar::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  .custom-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .custom-scrollbar::-webkit-scrollbar-thumb {
+    background-color: var(--primary);
+    border-radius: 9999px;
+  }
+  .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+    background-color: color-mix(in srgb, var(--primary) 100%, white 25%);
+  }
+}

--- a/src/pages/ProblemDetailsPage.tsx
+++ b/src/pages/ProblemDetailsPage.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 import {
    Download, Send, FileText,
   Users, Trophy, Activity, CheckCircle2, ArrowLeft, Loader2, Eye, EyeOff,
-  XCircle, PartyPopper, CheckCircle, Hash, WifiOff
+  XCircle, PartyPopper, CheckCircle, Hash, WifiOff, X
 } from "lucide-react";
 import { Link, useParams, useNavigate } from "@tanstack/react-router";
 import { isAxiosError } from "axios";
@@ -18,9 +18,10 @@ import { PublicProblemResponseDTO, SubmitResponseDTO } from "@/api/sdk";
 import { CURRENT_VALUE_HINT } from "@/lib/problem-scoring";
 import { queryKeys } from "@/lib/query-keys";
 import ReactMarkdown from "react-markdown";
-import rehypeRaw from "rehype-raw"; 
-import remarkGfm from "remark-gfm"; 
+import rehypeRaw from "rehype-raw";
+import remarkGfm from "remark-gfm";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 
 /**
  * Por que o envio falhou — nunca por que a resposta está errada. Os três casos
@@ -60,6 +61,7 @@ export function ProblemDetailsPage() {
 
   const [userAnswer, setUserAnswer] = useState("");
   const [showAnswer, setShowAnswer] = useState(false);
+  const [isAnswerPanelOpen, setIsAnswerPanelOpen] = useState(false);
 
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [showErrorModal, setShowErrorModal] = useState(false);
@@ -177,10 +179,11 @@ export function ProblemDetailsPage() {
   };
 
   return (
-    <div className="pt-16 bg-[#0a0a0b] text-white flex flex-col lg:flex-row h-screen overflow-hidden">
-      
-      <div className="flex-1 flex flex-col border-r border-white/5 overflow-hidden">
-        
+    <div className="pt-16 bg-[#0a0a0b] text-white min-h-screen overflow-y-auto custom-scrollbar">
+      <div className="flex flex-col lg:flex-row">
+
+      <div className="flex-1 flex flex-col border-r border-white/5">
+
         <div className={cn("relative w-full overflow-hidden shrink-0", problem.bannerUrl ? "min-h-60" : "h-60")}>
           <Link to="/problemas" className="absolute top-6 left-6 z-30">
             <Button variant="ghost" size="icon" className="bg-black/50 hover:bg-black/80 rounded-full">
@@ -229,15 +232,15 @@ export function ProblemDetailsPage() {
           </div>
         </div>
 
-        <div className="flex-1 flex flex-col p-10 gap-8 overflow-hidden">
-          
+        <div className="flex flex-col p-10 gap-8">
+
           <div className="flex items-center gap-3 text-primary/80 border-b border-white/5 pb-4 shrink-0">
             <FileText size={20} />
             <h3 className="font-bold uppercase tracking-[0.2em] text-xs">Instruções do Desafio</h3>
           </div>
 
-          <div className="flex-1 overflow-y-auto custom-scrollbar pr-4">
-            <div className="prose prose-invert max-w-none pb-10 
+          <div className="pr-4">
+            <div className="prose prose-invert max-w-none pb-10
               prose-headings:text-white prose-a:text-primary prose-strong:text-white
               prose-img:rounded-3xl prose-img:border prose-img:border-white/10 prose-img:shadow-2xl">
               <div className="text-lg text-gray-400 leading-relaxed font-medium">
@@ -265,7 +268,18 @@ export function ProblemDetailsPage() {
         </div>
       </div>
 
-      <div className="w-full lg:w-[400px] bg-white/[0.01] p-8 flex flex-col gap-6 overflow-y-auto custom-scrollbar shrink-0 h-full">
+      <Sheet open={isAnswerPanelOpen} onOpenChange={setIsAnswerPanelOpen}>
+        <SheetTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="fixed bottom-24 right-6 z-40 h-14 w-14 rounded-full bg-primary text-white shadow-lg shadow-primary/30 hover:bg-primary/90"
+          >
+            {isAnswerPanelOpen ? <X size={22} /> : <Send size={22} />}
+            <span className="sr-only">{isAnswerPanelOpen ? "Fechar painel de resposta" : "Abrir painel de resposta"}</span>
+          </Button>
+        </SheetTrigger>
+        <SheetContent side="right" className="w-full sm:w-100 sm:max-w-100 bg-[#0a0a0b] border-white/5 p-8 flex flex-col gap-6 overflow-y-auto custom-scrollbar">
         <div className="space-y-3">
           <Label className="text-[11px] font-black uppercase tracking-[0.3em] text-gray-500 ml-1">Recursos de Entrada</Label>
           <div className="p-4 rounded-[24px] bg-white/[0.03] border border-white/5 flex items-center justify-between group hover:border-primary/40 transition-all">
@@ -358,6 +372,8 @@ export function ProblemDetailsPage() {
             </div>
           )}
         </div>
+        </SheetContent>
+      </Sheet>
       </div>
 
       <Dialog open={showSuccessModal} onOpenChange={setShowSuccessModal}>

--- a/src/pages/ProblemDetailsPage.tsx
+++ b/src/pages/ProblemDetailsPage.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 import {
    Download, Send, FileText,
   Users, Trophy, Activity, CheckCircle2, ArrowLeft, Loader2, Eye, EyeOff,
-  XCircle, PartyPopper, CheckCircle, Hash, WifiOff, X
+  XCircle, PartyPopper, CheckCircle, Hash, WifiOff
 } from "lucide-react";
 import { Link, useParams, useNavigate } from "@tanstack/react-router";
 import { isAxiosError } from "axios";
@@ -275,8 +275,8 @@ export function ProblemDetailsPage() {
             size="icon"
             className="fixed bottom-24 right-6 z-40 h-14 w-14 rounded-full bg-primary text-white shadow-lg shadow-primary/30 hover:bg-primary/90"
           >
-            {isAnswerPanelOpen ? <X size={22} /> : <Send size={22} />}
-            <span className="sr-only">{isAnswerPanelOpen ? "Fechar painel de resposta" : "Abrir painel de resposta"}</span>
+            <Send size={22} />
+            <span className="sr-only">Abrir painel de resposta</span>
           </Button>
         </SheetTrigger>
         <SheetContent side="right" className="w-full sm:w-100 sm:max-w-100 bg-[#0a0a0b] border-white/5 p-8 flex flex-col gap-6 overflow-y-auto custom-scrollbar">

--- a/src/pages/ProblemDetailsPage.tsx
+++ b/src/pages/ProblemDetailsPage.tsx
@@ -21,7 +21,7 @@ import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 
 /**
  * Por que o envio falhou — nunca por que a resposta está errada. Os três casos
@@ -280,6 +280,9 @@ export function ProblemDetailsPage() {
           </Button>
         </SheetTrigger>
         <SheetContent side="right" className="w-full sm:w-100 sm:max-w-100 bg-[#0a0a0b] border-white/5 p-8 flex flex-col gap-6 overflow-y-auto custom-scrollbar">
+        <SheetHeader className="p-0">
+          <SheetTitle className="text-white">Painel de Resposta</SheetTitle>
+        </SheetHeader>
         <div className="space-y-3">
           <Label className="text-[11px] font-black uppercase tracking-[0.3em] text-gray-500 ml-1">Recursos de Entrada</Label>
           <div className="p-4 rounded-[24px] bg-white/[0.03] border border-white/5 flex items-center justify-between group hover:border-primary/40 transition-all">


### PR DESCRIPTION
## 🔗 Task no ClickUp

ID da Task:

## 📝 Descrição das mudanças

A tela de detalhe do problema (`ProblemDetailsPage.tsx`) tinha dois containers de scroll aninhados — o banner ficava fixo fora do fluxo (`h-screen overflow-hidden` no container raiz e na coluna esquerda) enquanto só o texto do enunciado rolava, isolado, dentro de uma caixa própria (`overflow-y-auto` na linha 239). A coluna direita (recursos, taxa de acerto, ID, formulário de resposta) era sempre visível, ocupando 400px fixos mesmo quando o aluno só queria ler. E a classe `custom-scrollbar`, usada em 5 lugares do app, nunca tinha definição em CSS — o navegador sempre mostrava a scrollbar padrão do SO.

Este PR:
- Remove os containers de scroll aninhados: a página agora rola em fluxo único (`min-h-screen overflow-y-auto` no wrapper raiz), com o banner saindo naturalmente da viewport ao rolar.
- Transforma a coluna direita inteira num `Sheet` (shadcn) retrátil — escondido por padrão, sem persistência entre carregamentos, aberto por um botão flutuante (FAB) fixo no canto inferior direito.
- Define `.custom-scrollbar` em `index.css` com os tokens do tema (`--primary` no thumb, track transparente, hover mais claro via `color-mix`), cobrindo de uma vez os 5 usos existentes da classe.

**Achado durante a validação, não previsto no plano original:** a ideia inicial era trocar o ícone do próprio botão flutuante para um X e reusar o mesmo clique para fechar o painel. Na prática isso não funciona: o Radix trava `pointer-events` no `<body>` inteiro enquanto o `Sheet` (modal) está aberto — só o conteúdo do próprio painel fica clicável — então o botão flutuante fica fisicamente inerte assim que o painel abre, e mostrar um ícone de "fechar" ali era uma affordance enganosa (parece clicável, nunca é). O botão agora só abre; fechar acontece pelo X nativo do `SheetContent`, por clique fora (overlay) ou Esc — os três testados e funcionando.

## 🎯 Tipo de Mudança

- [ ] Bug fix (correção de bug)
- [x] New feature (nova funcionalidade)
- [ ] Documentation (documentação)
- [x] Refactoring (refatoração)
- [ ] Test (testes)

## 📸 Evidências

Validado com Playwright + chromium do sistema, contra um back local e banco descartável (sem tocar no `.env` de dev), autenticado como aluno com um problema de enunciado longo:

- **Scroll único**: `document.querySelectorAll('[class*="overflow-y-auto"]')` dentro do bloco do enunciado retorna `0` (antes, a caixa própria do texto contava `>0`). Rolando `900px`, o `<img>` do banner sai da viewport (`top` vai de `64` para `-836`) junto com `window.scrollY === 900` — um scroll só, sem "caixinha" isolada.
- **Painel escondido por padrão**: no load, o rótulo "Recursos de Entrada" não está visível (`offsetParent === null`).
- **Abre pelo FAB**: clique no botão flutuante mostra o painel — "Recursos de Entrada" e "Sua Resposta" ficam visíveis.
- **Fecha pelo X nativo / clique fora / Esc**: os três fecham o painel (`data-slot="sheet-content"` some do DOM).
- **Sempre fechado ao recarregar**: `page.reload()` confirma que o painel volta fechado (sem persistência).
- **Scrollbar estilizada**: `getComputedStyle(document.querySelector('.custom-scrollbar')).scrollbarColor` resolve para `rgb(151, 0, 148) rgba(0, 0, 0, 0)` — exatamente `--primary` do tema dark (`#970094`) sobre track transparente.
- **Regressão checada**: `ProfilePage` e `MembersPage` (que já usavam `.custom-scrollbar`) sem mudança visual. Em contexto móvel (375×667, `isMobile`/`hasTouch`), o campo "Sua Resposta" fica totalmente dentro da viewport com o painel aberto (`top: 570, bottom: 626`, sem overflow horizontal) — não fecha a front#14, mas não piora o sintoma dela.

## ✅ Checklist

- [x] Código segue os padrões do projeto
- [x] Self-review foi feito
- [x] Código foi testado localmente (`npm run build` e `npm run lint` limpos; smoke test manual no browser via Playwright, sem infraestrutura de teste automatizado — este projeto não tem testes)

## 📌 Notas adicionais

Sem mudança de contrato com o back — não foi necessário regerar o SDK.

Closes #32