### PR TITLE
fix(chamada): regera sdk e tipa historico de presencas

### DIFF
--- a/src/api/sdk/.openapi-generator/FILES
+++ b/src/api/sdk/.openapi-generator/FILES
@@ -14,6 +14,8 @@ docs/FileReponseDTO.md
 docs/LoginApi.md
 docs/LoginRequestDTO.md
 docs/LoginResponseDTO.md
+docs/MyAttendanceHistoryItemDto.md
+docs/MyAttendancesResponseDto.md
 docs/ProblemResponseDTO.md
 docs/ProblemsApi.md
 docs/PublicProblemResponseDTO.md

--- a/src/api/sdk/api.ts
+++ b/src/api/sdk/api.ts
@@ -256,6 +256,62 @@ export interface LoginResponseDTO {
 /**
  * 
  * @export
+ * @interface MyAttendanceHistoryItemDto
+ */
+export interface MyAttendanceHistoryItemDto {
+    /**
+     * ID da chamada
+     * @type {string}
+     * @memberof MyAttendanceHistoryItemDto
+     */
+    'rollCallId': string;
+    /**
+     * Data da chamada no formato ISO 8601
+     * @type {string}
+     * @memberof MyAttendanceHistoryItemDto
+     */
+    'date': string;
+    /**
+     * Se o usuário esteve presente nessa chamada
+     * @type {boolean}
+     * @memberof MyAttendanceHistoryItemDto
+     */
+    'isPresent': boolean;
+}
+/**
+ * 
+ * @export
+ * @interface MyAttendancesResponseDto
+ */
+export interface MyAttendancesResponseDto {
+    /**
+     * Total de chamadas realizadas
+     * @type {number}
+     * @memberof MyAttendancesResponseDto
+     */
+    'totalClasses': number;
+    /**
+     * Total de presenças do usuário
+     * @type {number}
+     * @memberof MyAttendancesResponseDto
+     */
+    'totalAttendances': number;
+    /**
+     * Total de faltas do usuário
+     * @type {number}
+     * @memberof MyAttendancesResponseDto
+     */
+    'totalMisses': number;
+    /**
+     * Histórico de presenças por chamada
+     * @type {Array<MyAttendanceHistoryItemDto>}
+     * @memberof MyAttendancesResponseDto
+     */
+    'history': Array<MyAttendanceHistoryItemDto>;
+}
+/**
+ * 
+ * @export
  * @interface ProblemResponseDTO
  */
 export interface ProblemResponseDTO {
@@ -2791,7 +2847,7 @@ export const RollCallApiAxiosParamCreator = function (configuration?: Configurat
             };
         },
         /**
-         * Gera um QR Code com expiração de 15 segundos para a chamada informada. Acesso restrito a administradores.
+         * Gera um QR Code com expiração de 30 segundos para a chamada informada. Acesso restrito a administradores.
          * @summary Gerar QR Code
          * @param {string} id 
          * @param {*} [options] Override http request option.
@@ -3020,7 +3076,7 @@ export const RollCallApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Gera um QR Code com expiração de 15 segundos para a chamada informada. Acesso restrito a administradores.
+         * Gera um QR Code com expiração de 30 segundos para a chamada informada. Acesso restrito a administradores.
          * @summary Gerar QR Code
          * @param {string} id 
          * @param {*} [options] Override http request option.
@@ -3038,7 +3094,7 @@ export const RollCallApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async rollCallControllerGetMyAttendances(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+        async rollCallControllerGetMyAttendances(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<MyAttendancesResponseDto>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.rollCallControllerGetMyAttendances(options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['RollCallApi.rollCallControllerGetMyAttendances']?.[localVarOperationServerIndex]?.url;
@@ -3133,7 +3189,7 @@ export const RollCallApiFactory = function (configuration?: Configuration, baseP
             return localVarFp.rollCallControllerFindOne(id, options).then((request) => request(axios, basePath));
         },
         /**
-         * Gera um QR Code com expiração de 15 segundos para a chamada informada. Acesso restrito a administradores.
+         * Gera um QR Code com expiração de 30 segundos para a chamada informada. Acesso restrito a administradores.
          * @summary Gerar QR Code
          * @param {string} id 
          * @param {*} [options] Override http request option.
@@ -3148,7 +3204,7 @@ export const RollCallApiFactory = function (configuration?: Configuration, baseP
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        rollCallControllerGetMyAttendances(options?: RawAxiosRequestConfig): AxiosPromise<void> {
+        rollCallControllerGetMyAttendances(options?: RawAxiosRequestConfig): AxiosPromise<MyAttendancesResponseDto> {
             return localVarFp.rollCallControllerGetMyAttendances(options).then((request) => request(axios, basePath));
         },
         /**
@@ -3239,7 +3295,7 @@ export class RollCallApi extends BaseAPI {
     }
 
     /**
-     * Gera um QR Code com expiração de 15 segundos para a chamada informada. Acesso restrito a administradores.
+     * Gera um QR Code com expiração de 30 segundos para a chamada informada. Acesso restrito a administradores.
      * @summary Gerar QR Code
      * @param {string} id 
      * @param {*} [options] Override http request option.

--- a/src/api/sdk/docs/MyAttendanceHistoryItemDto.md
+++ b/src/api/sdk/docs/MyAttendanceHistoryItemDto.md
@@ -1,0 +1,24 @@
+# MyAttendanceHistoryItemDto
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**rollCallId** | **string** | ID da chamada | [default to undefined]
+**date** | **string** | Data da chamada no formato ISO 8601 | [default to undefined]
+**isPresent** | **boolean** | Se o usuário esteve presente nessa chamada | [default to undefined]
+
+## Example
+
+```typescript
+import { MyAttendanceHistoryItemDto } from './api';
+
+const instance: MyAttendanceHistoryItemDto = {
+    rollCallId,
+    date,
+    isPresent,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/src/api/sdk/docs/MyAttendancesResponseDto.md
+++ b/src/api/sdk/docs/MyAttendancesResponseDto.md
@@ -1,0 +1,26 @@
+# MyAttendancesResponseDto
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**totalClasses** | **number** | Total de chamadas realizadas | [default to undefined]
+**totalAttendances** | **number** | Total de presenças do usuário | [default to undefined]
+**totalMisses** | **number** | Total de faltas do usuário | [default to undefined]
+**history** | [**Array&lt;MyAttendanceHistoryItemDto&gt;**](MyAttendanceHistoryItemDto.md) | Histórico de presenças por chamada | [default to undefined]
+
+## Example
+
+```typescript
+import { MyAttendancesResponseDto } from './api';
+
+const instance: MyAttendancesResponseDto = {
+    totalClasses,
+    totalAttendances,
+    totalMisses,
+    history,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/src/api/sdk/docs/RollCallApi.md
+++ b/src/api/sdk/docs/RollCallApi.md
@@ -230,7 +230,7 @@ No authorization required
 # **rollCallControllerGenerateQrCode**
 > rollCallControllerGenerateQrCode()
 
-Gera um QR Code com expiração de 15 segundos para a chamada informada. Acesso restrito a administradores.
+Gera um QR Code com expiração de 30 segundos para a chamada informada. Acesso restrito a administradores.
 
 ### Example
 
@@ -283,7 +283,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **rollCallControllerGetMyAttendances**
-> rollCallControllerGetMyAttendances()
+> MyAttendancesResponseDto rollCallControllerGetMyAttendances()
 
 Retorna o histórico de presenças do usuário autenticado.
 
@@ -307,7 +307,7 @@ This endpoint does not have any parameters.
 
 ### Return type
 
-void (empty response body)
+**MyAttendancesResponseDto**
 
 ### Authorization
 
@@ -316,7 +316,7 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
- - **Accept**: Not defined
+ - **Accept**: application/json
 
 
 ### HTTP response details

--- a/src/routes/authenticated/chamada/index.tsx
+++ b/src/routes/authenticated/chamada/index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import client from '@/api/client'
+import type { MyAttendancesResponseDto } from '@/api/sdk'
 import { QrScanner } from '@/components/QrScanner'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
@@ -20,18 +21,9 @@ function UserChamadaComponent() {
 
   const { data: myAttendancesData, isLoading } = useQuery({
     queryKey: ['my-attendances'],
-    queryFn: async () => {
+    queryFn: async (): Promise<MyAttendancesResponseDto> => {
       const response = await client.rollCall.rollCallControllerGetMyAttendances()
-      return response.data as unknown as {
-        totalClasses: number
-        totalAttendances: number
-        totalMisses: number
-        history: {
-          rollCallId: string
-          date: string
-          isPresent: boolean
-        }[]
-      }
+      return response.data
     },
   })
 


### PR DESCRIPTION
## 🔗 Task no ClickUp

ID da Task:

## 📝 Descrição das mudanças

O aluno via a própria tela "Presenças" (`/authenticated/chamada`) com toda linha da tabela tendo `key={undefined}`: o front lia `record.rollCallId` de um `as unknown as {...}` que mascarava o tipo real da resposta de `GET /roll-calls/my-attendances`, que só devolvia `id`.

O back PR #41 (`fix/vazamento-qrcode-my-attendances`, já mergeado) trocou essa rota por `MyAttendancesResponseDto`/`MyAttendanceHistoryItemDto` (sem `currentQrCode`, com `rollCallId` preenchido). Esta PR regera o SDK (`npm run generate:sdk` contra o back local já com o #41) e troca o cast manual em `chamada/index.tsx` pela importação do tipo gerado.

Sem mudança visual: mesmos totais, mesmas colunas, mesmo comportamento de scan/mutation.

Closes #34

## 🎯 Tipo de Mudança

- [x] Bug fix (correção de bug)
- [ ] New feature (nova funcionalidade)
- [ ] Documentation (documentação)
- [ ] Refactoring (refatoração)
- [ ] Test (testes)

## 📸 Evidências

**Antes** — `queryFn` com cast manual, `rollCallId` inexistente na resposta real (a rota só devolvia `id`), linhas da tabela com `key={undefined}`.

**Depois** — `curl` em `GET /roll-calls/my-attendances` com token de aluno semeado com histórico cruzado (1 presença, 1 falta):
```json
{
  "totalClasses": 2,
  "totalAttendances": 1,
  "totalMisses": 1,
  "history": [
    { "rollCallId": "ac270bdc-...", "date": "2026-08-01T10:00:00.000Z", "isPresent": true },
    { "rollCallId": "edc80c9e-...", "date": "2026-08-08T10:00:00.000Z", "isPresent": false }
  ]
}
```
Playwright em `/authenticated/chamada` (chromium do sistema, sessão injetada via `localStorage`): tabela mostrando `01 de agosto, 2026 — Presente` / `08 de agosto, 2026 — Faltou`, totais `2/1/1` batendo com o seed, zero warning de `key` no console.

`git diff src/api/sdk` restrito a `MyAttendancesResponseDto`/`MyAttendanceHistoryItemDto` novos, `rollCallControllerGetMyAttendances` trocando `AxiosPromise<void>` → `AxiosPromise<MyAttendancesResponseDto>`, e o doc de TTL do QR (15s→30s, comentário, não contrato).

## ✅ Checklist

- [x] Código segue os padrões do projeto
- [x] Self-review foi feito
- [x] Código foi testado localmente (`npm run build` + `npm run lint` limpos; smoke test via curl e Playwright acima — não há suíte de testes automatizados neste projeto)

## 📌 Notas adicionais

Também atualizei o `CLAUDE.md` da raiz, riscando o achado do back#19 (que estava listado como "aberto") e referenciando o back PR #41 e esta issue como o fechamento do lado do front.