### PR TITLE
fix(profile): valida tipo/tamanho do upload de foto no client

### DIFF
--- a/src/components/profile/PhotoUploadModal.tsx
+++ b/src/components/profile/PhotoUploadModal.tsx
@@ -16,10 +16,35 @@ interface PhotoUploadModalProps {
   user: UserWithAccount;
 }
 
+const ALLOWED_MIME_TYPES = ["image/png", "image/jpeg"];
+const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024;
+
 export function PhotoUploadModal({ isOpen, onClose, type, user }: PhotoUploadModalProps) {
   const [file, setFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const { refetchUser } = useAuth();
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files?.[0];
+    e.target.value = "";
+
+    if (!selected) {
+      setFile(null);
+      return;
+    }
+
+    if (!ALLOWED_MIME_TYPES.includes(selected.type)) {
+      toast.error("Formato inválido. Envie um arquivo PNG ou JPG.");
+      return;
+    }
+
+    if (selected.size > MAX_FILE_SIZE_BYTES) {
+      toast.error("Arquivo muito grande. O tamanho máximo é 2MB.");
+      return;
+    }
+
+    setFile(selected);
+  };
 
   const handleUpload = async () => {
     if (!file || !user) return;
@@ -27,11 +52,17 @@ export function PhotoUploadModal({ isOpen, onClose, type, user }: PhotoUploadMod
     setIsUploading(true);
     try {
       const response = await client.file.fileControllerCreate(file);
-      const imageUrl = response.data[0].fileUrl;
-      const updatePayload: UpdateUserDTO = type === "avatar" 
-        ? { avatarUrl: imageUrl } 
+      const imageUrl = response.data[0]?.fileUrl;
+
+      if (!imageUrl) {
+        toast.error("O upload não retornou um arquivo válido. Tente novamente.");
+        return;
+      }
+
+      const updatePayload: UpdateUserDTO = type === "avatar"
+        ? { avatarUrl: imageUrl }
         : { bannerUrl: imageUrl };
-      
+
       await client.user.userControllerUpdateUser(user.id, updatePayload);
 
       try {
@@ -68,10 +99,10 @@ export function PhotoUploadModal({ isOpen, onClose, type, user }: PhotoUploadMod
           >
             <input 
               id={`file-input-${type}`}
-              type="file" 
-              className="hidden" 
-              accept="image/*"
-              onChange={(e) => setFile(e.target.files?.[0] || null)}
+              type="file"
+              className="hidden"
+              accept={ALLOWED_MIME_TYPES.join(",")}
+              onChange={handleFileChange}
             />
             <UploadCloud className={cn("h-10 w-10 transition-colors", file ? 'text-primary' : 'text-gray-500')} />
             <div className="text-center">


### PR DESCRIPTION
## 🔗 Task no ClickUp

ID da Task:

## 📝 Descrição das mudanças

O modal de upload de avatar/banner ([PhotoUploadModal.tsx](src/components/profile/PhotoUploadModal.tsx)) prometia "PNG ou JPG (Máx 2MB)" mas não validava nada no client antes de enviar, e acessava `response.data[0].fileUrl` sem checar se o array veio vazio.

- Valida o tipo do arquivo (`image/png`/`image/jpeg`) e o tamanho (≤2MB, mesmo limite do back) na seleção, antes de habilitar o botão "Confirmar" — com toast de erro explicando o motivo.
- `accept` do `<input type="file">` alinhado aos tipos aceitos.
- Reseta o `<input>` após cada seleção, para que escolher o mesmo arquivo inválido duas vezes dispare a validação de novo.
- Trata retorno vazio de `fileControllerCreate` com um toast de erro em vez de quebrar acessando `response.data[0].fileUrl` de um array vazio.

Closes #17

### Antes / Depois (smoke test manual)

Back local (porta 3001) + banco descartável + Playwright/chromium autenticado na tela de perfil (`/authenticated/profile`), testando a seleção de arquivo no modal de avatar:

**Antes** (comportamento no `main`): qualquer arquivo selecionado habilitava "Confirmar" imediatamente, sem checar tipo/tamanho — a validação real só existia no back.

**Depois**:
- Arquivo `.txt` selecionado → toast "Formato inválido. Envie um arquivo PNG ou JPG." e botão "Confirmar" continua desabilitado.
- PNG de 3MB selecionado → toast "Arquivo muito grande. O tamanho máximo é 2MB." e botão continua desabilitado.
- PNG de 76 bytes (dentro do limite) selecionado → botão habilita e mostra o nome do arquivo.
- Clique em "Confirmar" chega a bater no back (requisição `POST /file`), confirmando que o fluxo de upload não foi quebrado pela validação nova.

## 🎯 Tipo de Mudança

- [x] Bug fix (correção de bug)
- [ ] New feature (nova funcionalidade)
- [ ] Documentation (documentação)
- [ ] Refactoring (refatoração)
- [ ] Test (testes)

## 📸 Evidências

Validado via lint (`npm run lint`) e build (`npm run build`) limpos, e smoke test manual descrito acima (Playwright + chromium do sistema, back local + banco descartável).

## ✅ Checklist

- [x] Código segue os padrões do projeto
- [x] Self-review foi feito
- [x] Código foi testado localmente

## 📌 Notas adicionais

Task-filha do par fullstack; a validação server-side (a barreira real) já existe no back e não foi alterada.