### PR TITLE
feat(auth): OTP de 6 dígitos, reenvio de código e feedback de expiração

### DIFF
--- a/src/api/sdk/api.ts
+++ b/src/api/sdk/api.ts
@@ -640,7 +640,7 @@ export interface ResetPasswordDTO {
      */
     'tokenId': string;
     /**
-     * Indicates if the token has 4 digits
+     * Indicates if the token has 6 digits
      * @type {string}
      * @memberof ResetPasswordDTO
      */
@@ -1141,7 +1141,7 @@ export interface ValidateResetPasswordDTO {
      */
     'tokenId': string;
     /**
-     * Indicates if the token has 4 digits
+     * Indicates if the token has 6 digits
      * @type {string}
      * @memberof ValidateResetPasswordDTO
      */
@@ -1160,7 +1160,7 @@ export interface ValidateSignupDTO {
      */
     'tokenId': string;
     /**
-     * Indicates if the token has 4 digits
+     * Indicates if the token has 6 digits
      * @type {string}
      * @memberof ValidateSignupDTO
      */
@@ -1205,7 +1205,7 @@ export interface ValidateSignupResponse {
 export const FileApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
-         * This endpoint allows you to upload a new files in the system and atributes to a user.        Limits: Up to 10 files per upload, and each file can have up to 100 MB.
+         * This endpoint allows you to upload a new files in the system and atributes to a user.       Limits: Up to 1 file(s) per upload, each up to 2 MB, mimetype in [image/jpeg, image/png, image/gif, image/webp].
          * @summary Upload a new files
          * @param {File} [files] 
          * @param {*} [options] Override http request option.
@@ -1392,7 +1392,7 @@ export const FileApiFp = function(configuration?: Configuration) {
     const localVarAxiosParamCreator = FileApiAxiosParamCreator(configuration)
     return {
         /**
-         * This endpoint allows you to upload a new files in the system and atributes to a user.        Limits: Up to 10 files per upload, and each file can have up to 100 MB.
+         * This endpoint allows you to upload a new files in the system and atributes to a user.       Limits: Up to 1 file(s) per upload, each up to 2 MB, mimetype in [image/jpeg, image/png, image/gif, image/webp].
          * @summary Upload a new files
          * @param {File} [files] 
          * @param {*} [options] Override http request option.
@@ -1467,7 +1467,7 @@ export const FileApiFactory = function (configuration?: Configuration, basePath?
     const localVarFp = FileApiFp(configuration)
     return {
         /**
-         * This endpoint allows you to upload a new files in the system and atributes to a user.        Limits: Up to 10 files per upload, and each file can have up to 100 MB.
+         * This endpoint allows you to upload a new files in the system and atributes to a user.       Limits: Up to 1 file(s) per upload, each up to 2 MB, mimetype in [image/jpeg, image/png, image/gif, image/webp].
          * @summary Upload a new files
          * @param {File} [files] 
          * @param {*} [options] Override http request option.
@@ -1527,7 +1527,7 @@ export const FileApiFactory = function (configuration?: Configuration, basePath?
  */
 export class FileApi extends BaseAPI {
     /**
-     * This endpoint allows you to upload a new files in the system and atributes to a user.        Limits: Up to 10 files per upload, and each file can have up to 100 MB.
+     * This endpoint allows you to upload a new files in the system and atributes to a user.       Limits: Up to 1 file(s) per upload, each up to 2 MB, mimetype in [image/jpeg, image/png, image/gif, image/webp].
      * @summary Upload a new files
      * @param {File} [files] 
      * @param {*} [options] Override http request option.

--- a/src/api/sdk/docs/FileApi.md
+++ b/src/api/sdk/docs/FileApi.md
@@ -13,7 +13,7 @@ All URIs are relative to *http://localhost*
 # **fileControllerCreate**
 > Array<FileReponseDTO> fileControllerCreate()
 
-This endpoint allows you to upload a new files in the system and atributes to a user.        Limits: Up to 10 files per upload, and each file can have up to 100 MB.
+This endpoint allows you to upload a new files in the system and atributes to a user.       Limits: Up to 1 file(s) per upload, each up to 2 MB, mimetype in [image/jpeg, image/png, image/gif, image/webp].
 
 ### Example
 
@@ -58,8 +58,8 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 |**201** | Files successfully uploaded. |  -  |
-|**400** | Bad request. The input data is invalid or missing. |  -  |
-|**413** | File size exceeds the maximum size allowed or the quantity of files to be uploaded exceeded: Maximum file sie: 100 | Allowed files quantity: 10 |  -  |
+|**400** | Bad request. The input data is invalid or missing, or the file mimetype is not in [image/jpeg, image/png, image/gif, image/webp]. |  -  |
+|**413** | File size exceeds the maximum size allowed or the quantity of files to be uploaded exceeded: Maximum file sie: 2 | Allowed files quantity: 1 |  -  |
 |**500** | Internal server error. An unexpected error occurred while processing the request. |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/src/api/sdk/docs/ResetPasswordDTO.md
+++ b/src/api/sdk/docs/ResetPasswordDTO.md
@@ -6,7 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **tokenId** | **string** | Token id | [default to undefined]
-**token** | **string** | Indicates if the token has 4 digits | [default to undefined]
+**token** | **string** | Indicates if the token has 6 digits | [default to undefined]
 **newPassword** | **string** | New password for the user | [default to undefined]
 
 ## Example

--- a/src/api/sdk/docs/ValidateResetPasswordDTO.md
+++ b/src/api/sdk/docs/ValidateResetPasswordDTO.md
@@ -6,7 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **tokenId** | **string** | Token id | [default to undefined]
-**token** | **string** | Indicates if the token has 4 digits | [default to undefined]
+**token** | **string** | Indicates if the token has 6 digits | [default to undefined]
 
 ## Example
 

--- a/src/api/sdk/docs/ValidateSignupDTO.md
+++ b/src/api/sdk/docs/ValidateSignupDTO.md
@@ -6,7 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **tokenId** | **string** | Token id | [default to undefined]
-**token** | **string** | Indicates if the token has 4 digits | [default to undefined]
+**token** | **string** | Indicates if the token has 6 digits | [default to undefined]
 
 ## Example
 

--- a/src/components/ForgotPasswordModal.tsx
+++ b/src/components/ForgotPasswordModal.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import * as z from "zod"
-import { Loader2, Mail, KeyRound, Lock, ArrowLeft } from "lucide-react"
+import { Loader2, Mail, KeyRound, Lock, ArrowLeft, RotateCw } from "lucide-react"
 import { toast } from "sonner"
 
 import client from "@/api/client"
@@ -21,6 +21,10 @@ import {
   InputOTPGroup,
   InputOTPSlot,
 } from "@/components/ui/input-otp"
+import { useCountdown, formatCountdown } from "@/hooks/use-countdown"
+
+const OTP_LENGTH = 6
+const RESEND_COOLDOWN_SECONDS = 30
 
 const emailSchema = z.object({
   email: z.string().email("Insira um email válido"),
@@ -49,9 +53,16 @@ type Step = "EMAIL" | "OTP" | "NEW_PASSWORD"
 export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModalProps) {
   const [step, setStep] = useState<Step>("EMAIL")
   const [isLoading, setIsLoading] = useState(false)
+  const [isResending, setIsResending] = useState(false)
   const [tokenId, setTokenId] = useState("")
   const [otp, setOtp] = useState("")
   const [email, setEmail] = useState("")
+  const [expiresAtMs, setExpiresAtMs] = useState<number | null>(null)
+  const [resendAvailableAt, setResendAvailableAt] = useState<number | null>(null)
+
+  const secondsUntilExpiry = useCountdown(expiresAtMs)
+  const isOtpExpired = expiresAtMs !== null && secondsUntilExpiry === 0
+  const resendCooldown = useCountdown(resendAvailableAt)
 
   const emailForm = useForm<z.infer<typeof emailSchema>>({
     resolver: zodResolver(emailSchema),
@@ -61,15 +72,22 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
     resolver: zodResolver(passwordSchema),
   })
 
+  const startOtpWindow = (newTokenId: string, newExpiresAt: string) => {
+    setTokenId(newTokenId)
+    setExpiresAtMs(new Date(newExpiresAt).getTime())
+    setResendAvailableAt(Date.now() + RESEND_COOLDOWN_SECONDS * 1000)
+    setOtp("")
+  }
+
   const handleRequestReset = async (data: z.infer<typeof emailSchema>) => {
     setIsLoading(true)
     try {
       const response = await client.resetPassword.resetPasswordControllerRequestResetPassword({
         email: data.email,
       })
-      
+
       if (response.data.id) {
-        setTokenId(response.data.id)
+        startOtpWindow(response.data.id, response.data.expiresAt)
         setEmail(data.email)
         setStep("OTP")
         toast.success("Código enviado!", { description: "Verifique sua caixa de entrada." })
@@ -82,19 +100,39 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
     }
   }
 
+  const handleResendOtp = async () => {
+    setIsResending(true)
+    try {
+      const response = await client.resetPassword.resetPasswordControllerRequestResetPassword({
+        email,
+      })
+
+      if (response.data.id) {
+        startOtpWindow(response.data.id, response.data.expiresAt)
+        toast.success("Novo código enviado!", { description: "O código anterior deixou de ser válido." })
+      }
+    } catch (error) {
+      console.error(error)
+      toast.error("Erro ao reenviar código", { description: "Tente novamente em instantes." })
+    } finally {
+      setIsResending(false)
+    }
+  }
+
   const handleVerifyOtp = async () => {
-    if (otp.length < 4) return
+    if (otp.length < OTP_LENGTH || isOtpExpired) return
     setIsLoading(true)
     try {
       await client.resetPassword.resetPasswordControllerValidateResetPassword({
         tokenId: tokenId,
         token: otp,
       })
-      
+
       setStep("NEW_PASSWORD")
       toast.success("Código validado!")
     } catch (error) {
       console.error(error)
+      setOtp("")
       toast.error("Código inválido", { description: "Tente novamente." })
     } finally {
       setIsLoading(false)
@@ -125,6 +163,8 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
     setTimeout(() => {
       setStep("EMAIL")
       setOtp("")
+      setExpiresAtMs(null)
+      setResendAvailableAt(null)
       emailForm.reset()
       passwordForm.reset()
     }, 300)
@@ -137,7 +177,7 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
           <DialogTitle className="text-foreground">Recuperar Senha</DialogTitle>
           <DialogDescription className="text-muted-foreground">
             {step === "EMAIL" && "Insira seu email para receber o código de recuperação."}
-            {step === "OTP" && `Enviamos um código de 4 dígitos para ${email}.`}
+            {step === "OTP" && `Enviamos um código de 6 dígitos para ${email}.`}
             {step === "NEW_PASSWORD" && "Crie uma nova senha segura para sua conta."}
           </DialogDescription>
         </DialogHeader>
@@ -174,27 +214,48 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
 
           {step === "OTP" && (
             <div className="flex flex-col items-center space-y-6 animate-in fade-in slide-in-from-right-4">
-              <InputOTP maxLength={4} value={otp} onChange={setOtp}>
+              <InputOTP maxLength={OTP_LENGTH} value={otp} onChange={setOtp} disabled={isOtpExpired}>
                 <InputOTPGroup className="gap-2">
                   <InputOTPSlot index={0} className="h-12 w-12 text-lg border-input bg-background text-foreground shadow-sm" />
                   <InputOTPSlot index={1} className="h-12 w-12 text-lg border-input bg-background text-foreground shadow-sm" />
                   <InputOTPSlot index={2} className="h-12 w-12 text-lg border-input bg-background text-foreground shadow-sm" />
                   <InputOTPSlot index={3} className="h-12 w-12 text-lg border-input bg-background text-foreground shadow-sm" />
+                  <InputOTPSlot index={4} className="h-12 w-12 text-lg border-input bg-background text-foreground shadow-sm" />
+                  <InputOTPSlot index={5} className="h-12 w-12 text-lg border-input bg-background text-foreground shadow-sm" />
                 </InputOTPGroup>
               </InputOTP>
-              
+
+              <p className="text-xs text-muted-foreground -mt-3">
+                {isOtpExpired
+                  ? "Código expirado. Solicite um novo código."
+                  : `Código expira em ${formatCountdown(secondsUntilExpiry)}`}
+              </p>
+
               <div className="w-full space-y-2">
-                <Button 
-                  onClick={handleVerifyOtp} 
-                  className="w-full h-11 bg-primary hover:bg-primary/90 text-primary-foreground font-semibold shadow-sm transition-all cursor-pointer" 
-                  disabled={isLoading || otp.length < 4}
+                <Button
+                  onClick={handleVerifyOtp}
+                  className="w-full h-11 bg-primary hover:bg-primary/90 text-primary-foreground font-semibold shadow-sm transition-all cursor-pointer"
+                  disabled={isLoading || otp.length < OTP_LENGTH || isOtpExpired}
                 >
                   {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : "Verificar Código"}
                 </Button>
-                <Button 
-                  variant="ghost" 
-                  className="w-full h-11 text-muted-foreground hover:text-foreground hover:bg-muted/50 cursor-pointer" 
-                  onClick={() => setStep("EMAIL")} 
+                <Button
+                  variant="outline"
+                  className="w-full h-11 cursor-pointer"
+                  onClick={handleResendOtp}
+                  disabled={isResending || resendCooldown > 0}
+                >
+                  {isResending ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <RotateCw className="mr-2 h-4 w-4" />
+                  )}
+                  {resendCooldown > 0 ? `Reenviar código (${resendCooldown}s)` : "Reenviar código"}
+                </Button>
+                <Button
+                  variant="ghost"
+                  className="w-full h-11 text-muted-foreground hover:text-foreground hover:bg-muted/50 cursor-pointer"
+                  onClick={() => setStep("EMAIL")}
                   disabled={isLoading}
                 >
                   <ArrowLeft className="mr-2 h-4 w-4" /> Voltar

--- a/src/components/signup/SignupForm.tsx
+++ b/src/components/signup/SignupForm.tsx
@@ -9,6 +9,7 @@ import client from "@/api/client"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { SignupRequestResponseDTO } from "@/api/sdk"
 
 const formSchema = z.object({
   name: z.string().min(2, "O nome deve ter pelo menos 2 caracteres."),
@@ -25,9 +26,9 @@ const formSchema = z.object({
 
 type FormValues = z.infer<typeof formSchema>
 
-export function SignupForm({ onSuccess }: { onSuccess: (tokenId: string) => void }) {
+export function SignupForm({ onSuccess }: { onSuccess: (response: SignupRequestResponseDTO, credentials: FormValues) => void }) {
   const navigate = useNavigate()
-  
+
   const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<FormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: { name: "", email: "", password: "" },
@@ -40,7 +41,7 @@ export function SignupForm({ onSuccess }: { onSuccess: (tokenId: string) => void
         toast.success("Conta criada com sucesso!", {
             description: "Enviamos um código para o seu email."
         })
-        onSuccess(data.id)
+        onSuccess(data, values)
       }
     } catch (error) {
       console.log(error)

--- a/src/components/signup/ValidateSignup.tsx
+++ b/src/components/signup/ValidateSignup.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
-import { Loader2, CheckCircle2, ArrowLeft } from "lucide-react"
+import { Loader2, CheckCircle2, ArrowLeft, Mail, RotateCw } from "lucide-react"
 import { toast } from "sonner"
 
 import client from "@/api/client"
@@ -10,19 +10,39 @@ import {
   InputOTPGroup,
   InputOTPSlot,
 } from "@/components/ui/input-otp"
+import { useCountdown, formatCountdown } from "@/hooks/use-countdown"
+
+const OTP_LENGTH = 6
+const RESEND_COOLDOWN_SECONDS = 30
+
+export interface SignupCredentials {
+  name: string
+  email: string
+  password: string
+}
 
 interface ValidateSignupProps {
   tokenId: string
+  expiresAt: string
+  credentials: SignupCredentials
   onBack: () => void
 }
 
-export function ValidateSignup({ tokenId, onBack }: ValidateSignupProps) {
+export function ValidateSignup({ tokenId: initialTokenId, expiresAt: initialExpiresAt, credentials, onBack }: ValidateSignupProps) {
   const [otp, setOtp] = useState("")
   const [isLoading, setIsLoading] = useState(false)
+  const [isResending, setIsResending] = useState(false)
+  const [tokenId, setTokenId] = useState(initialTokenId)
+  const [expiresAtMs, setExpiresAtMs] = useState(() => new Date(initialExpiresAt).getTime())
+  const [resendAvailableAt, setResendAvailableAt] = useState(() => Date.now() + RESEND_COOLDOWN_SECONDS * 1000)
   const navigate = useNavigate()
 
+  const secondsUntilExpiry = useCountdown(expiresAtMs)
+  const isOtpExpired = secondsUntilExpiry === 0
+  const resendCooldown = useCountdown(resendAvailableAt)
+
   const handleVerify = async () => {
-    if (otp.length < 4) return
+    if (otp.length < OTP_LENGTH || isOtpExpired) return
 
     setIsLoading(true)
     try {
@@ -30,18 +50,36 @@ export function ValidateSignup({ tokenId, onBack }: ValidateSignupProps) {
         tokenId: tokenId,
         token: otp,
       })
-      
+
       toast.success("Conta verificada com sucesso!", {
           description: "Você já pode fazer o seu login."
       })
       navigate({ to: "/login" })
     } catch (err) {
       console.error(err)
+      setOtp("")
       toast.error("Código inválido", {
         description: "O código inserido está incorreto. Tente novamente.",
       })
     } finally {
       setIsLoading(false)
+    }
+  }
+
+  const handleResend = async () => {
+    setIsResending(true)
+    try {
+      const { data } = await client.signup.signupControllerValidateSignup(credentials)
+      setTokenId(data.id)
+      setExpiresAtMs(new Date(data.expiresAt).getTime())
+      setResendAvailableAt(Date.now() + RESEND_COOLDOWN_SECONDS * 1000)
+      setOtp("")
+      toast.success("Novo código enviado!", { description: "O código anterior deixou de ser válido." })
+    } catch (err) {
+      console.error(err)
+      toast.error("Erro ao reenviar código", { description: "Tente novamente em instantes." })
+    } finally {
+      setIsResending(false)
     }
   }
 
@@ -55,31 +93,49 @@ export function ValidateSignup({ tokenId, onBack }: ValidateSignupProps) {
         </div>
         <h2 className="text-xl font-semibold">Verifique o seu email</h2>
         <p className="text-sm text-muted-foreground max-w-xs mx-auto">
-          Enviámos um código de 4 dígitos para o seu email. Insira-o abaixo para continuar.
+          Enviámos um código de 6 dígitos para o seu email. Insira-o abaixo para continuar.
         </p>
       </div>
 
-      <InputOTP maxLength={4} value={otp} onChange={setOtp}>
+      <InputOTP maxLength={OTP_LENGTH} value={otp} onChange={setOtp} disabled={isOtpExpired}>
         <InputOTPGroup className="gap-2">
           <InputOTPSlot index={0} className="h-12 w-12 text-lg border-input" />
           <InputOTPSlot index={1} className="h-12 w-12 text-lg border-input" />
           <InputOTPSlot index={2} className="h-12 w-12 text-lg border-input" />
           <InputOTPSlot index={3} className="h-12 w-12 text-lg border-input" />
+          <InputOTPSlot index={4} className="h-12 w-12 text-lg border-input" />
+          <InputOTPSlot index={5} className="h-12 w-12 text-lg border-input" />
         </InputOTPGroup>
       </InputOTP>
 
+      <p className="text-xs text-muted-foreground -mt-3">
+        {isOtpExpired
+          ? "Código expirado. Solicite um novo código."
+          : `Código expira em ${formatCountdown(secondsUntilExpiry)}`}
+      </p>
+
       <div className="w-full space-y-2">
-        <Button 
-            onClick={handleVerify} 
-            className="w-full h-11 font-semibold" 
-            disabled={isLoading || otp.length < 4}
+        <Button
+            onClick={handleVerify}
+            className="w-full h-11 font-semibold"
+            disabled={isLoading || otp.length < OTP_LENGTH || isOtpExpired}
         >
           {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <CheckCircle2 className="mr-2 h-4 w-4" />}
           Verificar Código
         </Button>
-        
-        <Button 
-            variant="ghost" 
+
+        <Button
+            variant="outline"
+            onClick={handleResend}
+            className="w-full"
+            disabled={isResending || resendCooldown > 0}
+        >
+          {isResending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RotateCw className="mr-2 h-4 w-4" />}
+          {resendCooldown > 0 ? `Reenviar código (${resendCooldown}s)` : "Reenviar código"}
+        </Button>
+
+        <Button
+            variant="ghost"
             onClick={onBack}
             className="w-full text-muted-foreground"
             disabled={isLoading}
@@ -90,5 +146,3 @@ export function ValidateSignup({ tokenId, onBack }: ValidateSignupProps) {
     </div>
   )
 }
-
-import { Mail } from "lucide-react"

--- a/src/hooks/use-countdown.ts
+++ b/src/hooks/use-countdown.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react"
+
+export function useCountdown(targetTimestamp: number | null) {
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    if (!targetTimestamp) return
+    const interval = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(interval)
+  }, [targetTimestamp])
+
+  if (!targetTimestamp) return 0
+  return Math.max(0, Math.ceil((targetTimestamp - now) / 1000))
+}
+
+export function formatCountdown(totalSeconds: number) {
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`
+}

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -3,14 +3,17 @@ import { useState } from "react"
 import { Rocket, Trophy, Users, Code2 } from "lucide-react"
 
 import { SignupForm } from "@/components/signup/SignupForm"
-import { ValidateSignup } from "@/components/signup/ValidateSignup"
+import { ValidateSignup, type SignupCredentials } from "@/components/signup/ValidateSignup"
+import { SignupRequestResponseDTO } from "@/api/sdk"
 
 export default function SignupPage() {
   const [step, setStep] = useState<1 | 2>(1)
-  const [tokenId, setTokenId] = useState<string>("")
+  const [signupResponse, setSignupResponse] = useState<SignupRequestResponseDTO | null>(null)
+  const [credentials, setCredentials] = useState<SignupCredentials | null>(null)
 
-  const handleSignupSuccess = (id: string) => {
-    setTokenId(id)
+  const handleSignupSuccess = (response: SignupRequestResponseDTO, values: SignupCredentials) => {
+    setSignupResponse(response)
+    setCredentials(values)
     setStep(2)
   }
 
@@ -80,12 +83,14 @@ export default function SignupPage() {
                         </p>
                     </div>
 
-                    {step === 1 ? (
+                    {step === 1 || !signupResponse || !credentials ? (
                         <SignupForm onSuccess={handleSignupSuccess} />
                     ) : (
-                        <ValidateSignup 
-                            tokenId={tokenId} 
-                            onBack={() => setStep(1)} 
+                        <ValidateSignup
+                            tokenId={signupResponse.id}
+                            expiresAt={signupResponse.expiresAt}
+                            credentials={credentials}
+                            onBack={() => setStep(1)}
                         />
                     )}
                 </div>


### PR DESCRIPTION
## 📝 Descrição das mudanças

Par front do back#39/back#43 (`fix/endurecer-token-2fa-reset`, já mergeado), que endureceu o token de 2FA/reset de senha: 4 dígitos com `Math.random()` viraram 6 dígitos com `crypto.randomInt`, com limite de 5 tentativas e revogação ao pedir novo código. As telas do front ainda tinham o input fixo em 4 slots — ficariam inutilizáveis assim que o back#43 fosse para produção.

- `ForgotPasswordModal.tsx` e `ValidateSignup.tsx`: `InputOTP` de 4 → **6 slots**, com o `maxLength`/validação de comprimento correspondentes.
- Botão de **reenviar código** nos dois fluxos, reaproveitando a rota já existente (`POST /signup` e `POST /reset-password/request` já revogam tokens anteriores e emitem um novo — não há endpoint dedicado de "resend"). O back não expõe rate limit próprio para essas rotas nem sinaliza cooldown, então o front fixa **30s** (`RESEND_COOLDOWN_SECONDS`, `ValidateSignup.tsx`/`ForgotPasswordModal.tsx`) — decisão do front, documentada no código.
- **Feedback de expiração**: contagem regressiva calculada a partir do `expiresAt` já devolvido por `POST /signup` e `POST /reset-password/request` (10 min e 15 min hoje). Ao expirar, o input é desabilitado e a mensagem convida a reenviar.
- **Limpeza do campo após erro**: código errado agora limpa o OTP nos dois fluxos (antes ficava preenchido).
- Novo hook `src/hooks/use-countdown.ts`, compartilhado pelos dois componentes (mesma necessidade de contagem regressiva para expiração e para o cooldown do reenvio).
- No cadastro, reenviar exige reemitir `name`/`email`/`password` (mesmo contrato de `POST /signup`) — `SignupForm` agora repassa a resposta completa (`id`+`expiresAt`) e as credenciais digitadas para `SignupPage`, que as encaminha para `ValidateSignup`.
- SDK regenerado (`npm run generate:sdk` contra o back local com o PR#43): só mudança de doc (comentário "4 dígitos" → "6 dígitos" nos DTOs de token) — sem mudança de shape de resposta. Comitado à parte (`chore(sdk): ...`) porque também trouxe drift já existente do contrato de upload de arquivo (`FileApi`) desde a última geração, sem relação com esta issue.

Closes #13

## 🎯 Tipo de Mudança

- [x] Bug fix (correção de bug)
- [x] New feature (nova funcionalidade)

## 📸 Evidências

Smoke test manual com back local (branch `main`, já com o PR#43) contra um Postgres descartável, front local apontando para ele, e `playwright-core` + chromium do sistema dirigindo as telas de verdade (login/signup reais, sem mocks).

**Cadastro (2FA) — fluxo completo, incluindo reenvio:**
```
=== SIGNUP + 2FA (happy path with resend) ===
Resend disabled right after send (expect true): true
Waiting ~31s for resend cooldown to clear...
Resend enabled after cooldown (expect true): true
Resend toast shown, previous token should now be revoked.
Fresh (non-revoked) token from DB: 240953
Signup 2FA validated OK, redirected to login.
```
Confirmado no banco que o reenvio revoga o token anterior e o novo token de 6 dígitos (`240953`) é o único válido.

**Código errado limpa o campo (fluxo de cadastro):**
```
OTP slots count (expect 6): 6
Expiry text: Código expira em 10:00
Resend disabled during cooldown (expect true): true
[console.error] AxiosError: Request failed with status code 400   # 000000 rejeitado, como esperado
Slots after wrong code (expect all empty): ["","","","","",""]
```

**Recuperação de senha — 6 dígitos, expiração de 15 min, validação:**
```
=== FORGOT PASSWORD (happy path) ===
Reset OTP slots (expect 6): 6
Reset expiry text (expect ~15:00): Código expira em 15:01
Reset token from DB: 011039
Reset OTP validated OK, moved to NEW_PASSWORD step.
```

`npm run lint` e `npm run build` passam.

## ✅ Checklist

- [x] Código segue os padrões do projeto
- [x] Self-review foi feito
- [x] Código foi testado localmente (Playwright contra back local, não mock)

## 📌 Notas adicionais

- Fora de escopo: o back não diferencia "expirado" de "inválido" no `internalKey` do fluxo de reset de senha (só o de cadastro tem `TOKEN_EXPIRED` próprio — ver observação no CLAUDE.md do back). O front cobre a expiração de forma local (contagem regressiva a partir do `expiresAt`), então isso não bloqueia a UX, mas fica registrado caso o back queira paridade entre os dois fluxos no futuro.
- O cooldown de 30s do botão de reenviar é uma decisão do front — o back não tem rate limit dedicado nessas rotas nem devolve um valor de retry-after.