### PR TITLE
feat(admin): adiciona ajuste de pontuação de usuários

### DIFF
--- a/src/api/sdk/.openapi-generator/FILES
+++ b/src/api/sdk/.openapi-generator/FILES
@@ -4,6 +4,7 @@ api.ts
 base.ts
 common.ts
 configuration.ts
+docs/AdjustUserPointsDTO.md
 docs/AttendRollCallDto.md
 docs/CreateProblemDTO.md
 docs/CreateRollCallDto.md

--- a/src/api/sdk/api.ts
+++ b/src/api/sdk/api.ts
@@ -26,6 +26,25 @@ import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError, operationServerM
 /**
  * 
  * @export
+ * @interface AdjustUserPointsDTO
+ */
+export interface AdjustUserPointsDTO {
+    /**
+     * Amount to add to (or, if negative, subtract from) allTimePoints
+     * @type {number}
+     * @memberof AdjustUserPointsDTO
+     */
+    'allTimePointsDelta'?: number;
+    /**
+     * Amount to add to (or, if negative, subtract from) monthlyPoints
+     * @type {number}
+     * @memberof AdjustUserPointsDTO
+     */
+    'monthlyPointsDelta'?: number;
+}
+/**
+ * 
+ * @export
  * @interface AttendRollCallDto
  */
 export interface AttendRollCallDto {
@@ -3923,6 +3942,46 @@ export class SubmitApi extends BaseAPI {
 export const UserApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
+         * Admin only. Applies a delta (positive or negative) to allTimePoints and/or monthlyPoints of any user. Each field is clamped at 0.
+         * @summary Adjust a user\'s points
+         * @param {string} id 
+         * @param {AdjustUserPointsDTO} adjustUserPointsDTO 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        userControllerAdjustUserPoints: async (id: string, adjustUserPointsDTO: AdjustUserPointsDTO, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'id' is not null or undefined
+            assertParamExists('userControllerAdjustUserPoints', 'id', id)
+            // verify required parameter 'adjustUserPointsDTO' is not null or undefined
+            assertParamExists('userControllerAdjustUserPoints', 'adjustUserPointsDTO', adjustUserPointsDTO)
+            const localVarPath = `/user/{id}/points`
+                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(adjustUserPointsDTO, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * This endpoint allows you to delete a user from the system.
          * @summary Delete a user
          * @param {string} id 
@@ -4227,6 +4286,20 @@ export const UserApiFp = function(configuration?: Configuration) {
     const localVarAxiosParamCreator = UserApiAxiosParamCreator(configuration)
     return {
         /**
+         * Admin only. Applies a delta (positive or negative) to allTimePoints and/or monthlyPoints of any user. Each field is clamped at 0.
+         * @summary Adjust a user\'s points
+         * @param {string} id 
+         * @param {AdjustUserPointsDTO} adjustUserPointsDTO 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async userControllerAdjustUserPoints(id: string, adjustUserPointsDTO: AdjustUserPointsDTO, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<UserResponseDTO>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.userControllerAdjustUserPoints(id, adjustUserPointsDTO, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['UserApi.userControllerAdjustUserPoints']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
          * This endpoint allows you to delete a user from the system.
          * @summary Delete a user
          * @param {string} id 
@@ -4350,6 +4423,17 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
     const localVarFp = UserApiFp(configuration)
     return {
         /**
+         * Admin only. Applies a delta (positive or negative) to allTimePoints and/or monthlyPoints of any user. Each field is clamped at 0.
+         * @summary Adjust a user\'s points
+         * @param {string} id 
+         * @param {AdjustUserPointsDTO} adjustUserPointsDTO 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        userControllerAdjustUserPoints(id: string, adjustUserPointsDTO: AdjustUserPointsDTO, options?: RawAxiosRequestConfig): AxiosPromise<UserResponseDTO> {
+            return localVarFp.userControllerAdjustUserPoints(id, adjustUserPointsDTO, options).then((request) => request(axios, basePath));
+        },
+        /**
          * This endpoint allows you to delete a user from the system.
          * @summary Delete a user
          * @param {string} id 
@@ -4445,6 +4529,19 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
  * @extends {BaseAPI}
  */
 export class UserApi extends BaseAPI {
+    /**
+     * Admin only. Applies a delta (positive or negative) to allTimePoints and/or monthlyPoints of any user. Each field is clamped at 0.
+     * @summary Adjust a user\'s points
+     * @param {string} id 
+     * @param {AdjustUserPointsDTO} adjustUserPointsDTO 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof UserApi
+     */
+    public userControllerAdjustUserPoints(id: string, adjustUserPointsDTO: AdjustUserPointsDTO, options?: RawAxiosRequestConfig) {
+        return UserApiFp(this.configuration).userControllerAdjustUserPoints(id, adjustUserPointsDTO, options).then((request) => request(this.axios, this.basePath));
+    }
+
     /**
      * This endpoint allows you to delete a user from the system.
      * @summary Delete a user

--- a/src/api/sdk/docs/AdjustUserPointsDTO.md
+++ b/src/api/sdk/docs/AdjustUserPointsDTO.md
@@ -1,0 +1,22 @@
+# AdjustUserPointsDTO
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**allTimePointsDelta** | **number** | Amount to add to (or, if negative, subtract from) allTimePoints | [optional] [default to undefined]
+**monthlyPointsDelta** | **number** | Amount to add to (or, if negative, subtract from) monthlyPoints | [optional] [default to undefined]
+
+## Example
+
+```typescript
+import { AdjustUserPointsDTO } from './api';
+
+const instance: AdjustUserPointsDTO = {
+    allTimePointsDelta,
+    monthlyPointsDelta,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/src/api/sdk/docs/UserApi.md
+++ b/src/api/sdk/docs/UserApi.md
@@ -4,6 +4,7 @@ All URIs are relative to *http://localhost*
 
 |Method | HTTP request | Description|
 |------------- | ------------- | -------------|
+|[**userControllerAdjustUserPoints**](#usercontrolleradjustuserpoints) | **PATCH** /user/{id}/points | Adjust a user\&#39;s points|
 |[**userControllerDeleteUser**](#usercontrollerdeleteuser) | **DELETE** /user/{id} | Delete a user|
 |[**userControllerGetAllUsers**](#usercontrollergetallusers) | **GET** /user | List all users|
 |[**userControllerGetMe**](#usercontrollergetme) | **GET** /user/me/{id} | Get a user|
@@ -13,6 +14,65 @@ All URIs are relative to *http://localhost*
 |[**userControllerGetUserById**](#usercontrollergetuserbyid) | **GET** /user/{id} | Get a user by ID|
 |[**userControllerResetUserPoints**](#usercontrollerresetuserpoints) | **POST** /user/reset-points | Reset user points|
 |[**userControllerUpdateUser**](#usercontrollerupdateuser) | **PATCH** /user/{id} | Update an existing user|
+
+# **userControllerAdjustUserPoints**
+> UserResponseDTO userControllerAdjustUserPoints(adjustUserPointsDTO)
+
+Admin only. Applies a delta (positive or negative) to allTimePoints and/or monthlyPoints of any user. Each field is clamped at 0.
+
+### Example
+
+```typescript
+import {
+    UserApi,
+    Configuration,
+    AdjustUserPointsDTO
+} from './api';
+
+const configuration = new Configuration();
+const apiInstance = new UserApi(configuration);
+
+let id: string; // (default to undefined)
+let adjustUserPointsDTO: AdjustUserPointsDTO; //
+
+const { status, data } = await apiInstance.userControllerAdjustUserPoints(
+    id,
+    adjustUserPointsDTO
+);
+```
+
+### Parameters
+
+|Name | Type | Description  | Notes|
+|------------- | ------------- | ------------- | -------------|
+| **adjustUserPointsDTO** | **AdjustUserPointsDTO**|  | |
+| **id** | [**string**] |  | defaults to undefined|
+
+
+### Return type
+
+**UserResponseDTO**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+|**200** | User points adjusted successfully. |  -  |
+|**400** | Bad request. Neither allTimePointsDelta nor monthlyPointsDelta was provided. |  -  |
+|**403** | Forbidden. Only admins can adjust user points. |  -  |
+|**404** | User not found. The user with the specified ID does not exist. |  -  |
+|**500** | Internal server error. An unexpected error occurred while processing the request. |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **userControllerDeleteUser**
 > userControllerDeleteUser(deleteUserDTO)

--- a/src/components/admin/UsersTable.tsx
+++ b/src/components/admin/UsersTable.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { RefreshCcw, Edit2, Trash2, Shield, User as UserIcon, AlertTriangle, Search, ImageOff } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { RefreshCcw, Edit2, Trash2, Shield, User as UserIcon, AlertTriangle, Search, ImageOff, Coins } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { toast } from "sonner";
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import client from "@/api/client";
-import { UserResponseDTO, UpdateUserDTO } from "@/api/sdk";
+import { UserResponseDTO, UpdateUserDTO, AdjustUserPointsDTO } from "@/api/sdk";
 import { UserInfoModal } from "@/components/ranking/UserInfoModal";
 import {
   COURSE_LABELS,
@@ -27,13 +27,17 @@ export function UsersTable() {
 
   const [editingUser, setEditingUser] = useState<UserResponseDTO | null>(null);
   const [deletingUser, setDeletingUser] = useState<UserResponseDTO | null>(null);
-  
+  const [adjustingUser, setAdjustingUser] = useState<UserResponseDTO | null>(null);
+
   const [selectedUser, setSelectedUser] = useState<UserResponseDTO | null>(null);
   const [isInfoModalOpen, setIsInfoModalOpen] = useState(false);
-  
+
   const [editFormData, setEditFormData] = useState<UpdateUserDTO>({});
   const [deletePassword, setDeletePassword] = useState("");
+  const [adjustFormData, setAdjustFormData] = useState<AdjustUserPointsDTO>({});
   const [actionLoading, setActionLoading] = useState(false);
+
+  const queryClient = useQueryClient();
 
   // React Query para buscar usuários
   const { data: response, isLoading: loading, refetch } = useQuery({
@@ -107,6 +111,46 @@ export function UsersTable() {
       toast.success("Usuário deletado com sucesso!");
     } catch {
       toast.error("Erro ao deletar o usuário!");
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleAdjustPoints = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!adjustingUser) return;
+
+    const { allTimePointsDelta, monthlyPointsDelta } = adjustFormData;
+
+    if (allTimePointsDelta === undefined && monthlyPointsDelta === undefined) {
+      toast.error("Preencha pelo menos um dos campos de pontos.");
+      return;
+    }
+    if (
+      (allTimePointsDelta !== undefined && !Number.isInteger(allTimePointsDelta)) ||
+      (monthlyPointsDelta !== undefined && !Number.isInteger(monthlyPointsDelta))
+    ) {
+      toast.error("Os deltas de pontos precisam ser números inteiros.");
+      return;
+    }
+
+    setActionLoading(true);
+    try {
+      await client.user.userControllerAdjustUserPoints(adjustingUser.id, {
+        allTimePointsDelta,
+        monthlyPointsDelta,
+      });
+
+      setAdjustingUser(null);
+      setAdjustFormData({});
+      await refetch();
+      queryClient.invalidateQueries({ queryKey: queryKeys.adminUsers });
+      queryClient.invalidateQueries({ queryKey: queryKeys.ranking('monthly') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.ranking('alltime') });
+      toast.success("Pontuação ajustada com sucesso!");
+    } catch (error) {
+      console.error("Erro ao ajustar pontos:", error);
+      toast.error("Erro ao ajustar a pontuação!");
     } finally {
       setActionLoading(false);
     }
@@ -248,7 +292,18 @@ export function UsersTable() {
                             </button>
                           )}
 
-                          <button 
+                          <button
+                            onClick={() => {
+                              setAdjustingUser(user);
+                              setAdjustFormData({});
+                            }}
+                            className="p-2 bg-amber-500/10 hover:bg-amber-500/20 text-amber-400 hover:text-amber-300 rounded-md transition-colors border border-amber-500/20"
+                            title="Ajustar Pontos"
+                          >
+                            <Coins size={16} />
+                          </button>
+
+                          <button
                             onClick={() => setDeletingUser(user)}
                             className="p-2 bg-red-500/10 hover:bg-red-500/20 text-red-400 hover:text-red-300 rounded-md transition-colors border border-red-500/20"
                             title="Eliminar Utilizador"
@@ -357,6 +412,84 @@ export function UsersTable() {
               </Button>
               <Button type="submit" disabled={actionLoading} className="bg-primary text-white hover:bg-primary/90">
                 {actionLoading ? "A guardar..." : "Guardar Alterações"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!adjustingUser} onOpenChange={(open) => !open && setAdjustingUser(null)}>
+        <DialogContent className="bg-[#0a0a0b] border-white/10 text-white sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Coins size={20} className="text-amber-400" />
+              Ajustar Pontos
+            </DialogTitle>
+          </DialogHeader>
+
+          <form onSubmit={handleAdjustPoints} className="space-y-4 py-2">
+            <p className="text-sm text-gray-400">
+              Ajustando a pontuação de <strong className="text-white">{adjustingUser?.name}</strong>. Informe um delta (positivo ou negativo) para pelo menos um dos campos.
+            </p>
+
+            <div className="space-y-2">
+              <Label htmlFor="allTimePointsDelta" className="text-gray-400">Delta de Pontos (Total)</Label>
+              <Input
+                id="allTimePointsDelta"
+                type="number"
+                step={1}
+                placeholder="ex: 20 ou -15"
+                value={adjustFormData.allTimePointsDelta ?? ""}
+                onChange={(e) =>
+                  setAdjustFormData({
+                    ...adjustFormData,
+                    allTimePointsDelta: e.target.value === "" ? undefined : Number(e.target.value),
+                  })
+                }
+                className="bg-white/5 border-white/10 text-white focus-visible:ring-primary"
+              />
+              {adjustFormData.allTimePointsDelta !== undefined && adjustingUser && (
+                <p className="text-xs text-gray-500">
+                  {adjustingUser.allTimePoints ?? 0} → {" "}
+                  <span className="text-primary font-semibold">
+                    {Math.max(0, (adjustingUser.allTimePoints ?? 0) + adjustFormData.allTimePointsDelta)}
+                  </span>
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="monthlyPointsDelta" className="text-gray-400">Delta de Pontos (Mês)</Label>
+              <Input
+                id="monthlyPointsDelta"
+                type="number"
+                step={1}
+                placeholder="ex: 20 ou -15"
+                value={adjustFormData.monthlyPointsDelta ?? ""}
+                onChange={(e) =>
+                  setAdjustFormData({
+                    ...adjustFormData,
+                    monthlyPointsDelta: e.target.value === "" ? undefined : Number(e.target.value),
+                  })
+                }
+                className="bg-white/5 border-white/10 text-white focus-visible:ring-primary"
+              />
+              {adjustFormData.monthlyPointsDelta !== undefined && adjustingUser && (
+                <p className="text-xs text-gray-500">
+                  {adjustingUser.monthlyPoints ?? 0} → {" "}
+                  <span className="text-primary font-semibold">
+                    {Math.max(0, (adjustingUser.monthlyPoints ?? 0) + adjustFormData.monthlyPointsDelta)}
+                  </span>
+                </p>
+              )}
+            </div>
+
+            <DialogFooter className="pt-4">
+              <Button type="button" variant="ghost" onClick={() => setAdjustingUser(null)} className="hover:bg-white/10 text-gray-300">
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={actionLoading} className="bg-primary text-white hover:bg-primary/90">
+                {actionLoading ? "A ajustar..." : "Confirmar Ajuste"}
               </Button>
             </DialogFooter>
           </form>


### PR DESCRIPTION
## 🔗 Task no ClickUp

ID da Task:

## 📝 Descrição das mudanças

Dá ao admin uma forma de corrigir a pontuação (`allTimePoints`/`monthlyPoints`) de qualquer usuário direto pela plataforma, sem precisar mexer no banco. Consome `PATCH /user/:id/points` (back#7 / PR back#45, já mergeado e deployado em produção).

- Novo botão "Ajustar Pontos" na coluna Ações da `UsersTable` (aba "Gerenciar Usuários" do admin), disponível em toda linha — incluindo a do próprio admin logado.
- Dialog com dois campos de delta opcionais (`allTimePointsDelta`, `monthlyPointsDelta`; pelo menos um obrigatório), cada um mostrando o preview "atual → resultado" com o clamp em 0, calculado no client só para exibição — o valor enviado à API é sempre o delta bruto digitado.
- Validação client-side de inteiro e de "pelo menos um campo preenchido", espelhando as regras do back.
- Sucesso: fecha o dialog, toast de confirmação, `refetch()` da tabela e invalidação de `adminUsers` + `ranking('monthly')` + `ranking('alltime')` — mesmo padrão já usado em `SubmissionsTable`.
- Erro: toast de erro, dialog permanece aberto com os valores digitados.
- SDK regenerado contra o back local (branch `main`, já com o endpoint) — diff conferido, só adição (`AdjustUserPointsDTO`, `userControllerAdjustUserPoints`).

### Antes / Depois

**Antes:** não havia forma de ajustar pontos pela UI; só editando o banco direto.

**Depois** (smoke test com Playwright + chromium do sistema, dois usuários semeados com pontos cruzados):
- Botão "Ajustar Pontos" presente em todas as 2 linhas da tabela (incluindo a do admin).
- Submit vazio bloqueado no client (sem round-trip à API).
- `1.5` num campo bloqueado no client.
- Preview de clamp: `100 + (-99999) → 0`.
- Preview normal: `125 + 25 → 150` / `350 + (-50) → 300`.
- Após confirmar: célula "Pontos (Total)" da tabela mudou de `125` para `150` via refetch por clique (0 eventos `load` de página).
- Ranking Mensal (view padrão) e Geral refletiram os novos valores (`300` e `150`) navegando por clique, sem `page.goto()` no meio — `0` eventos `load` extras, confirmando que a invalidação de cache funcionou de verdade.
- Erro de rede forçado (`route.abort`): toast de erro, dialog permanece aberto com o valor `30` digitado.
- Usuário comum autenticado tentando acessar `/authenticated/admin` é redirecionado para `/` (rota já protegida, sem mudança nesta PR).

## 🎯 Tipo de Mudança

- [ ] Bug fix (correção de bug)
- [x] New feature (nova funcionalidade)
- [ ] Documentation (documentação)
- [ ] Refactoring (refatoração)
- [ ] Test (testes)

## 📸 Evidências

Smoke test manual via Playwright + chromium do sistema (sem infra de teste automatizado no projeto), cobrindo todos os itens do critério de aceite da issue.

## ✅ Checklist

- [x] Código segue os padrões do projeto
- [x] Self-review foi feito
- [x] Código foi testado localmente

## 📌 Notas adicionais

Fora de escopo (decidido na spec, `.claude/specs/front-6-edicao-pontos-admin.md`): editar `problemsResolved`/`submissionsNumber`, desfazer um ajuste já aplicado, editar perfil de outro usuário, e um modo "definir valor final" (só delta).

Closes #6