### PR TITLE
fix(problemas): corrige gradientes que escurecem o banner do card e do detalhe

### DIFF
--- a/src/components/problems/ProblemCard.tsx
+++ b/src/components/problems/ProblemCard.tsx
@@ -55,11 +55,11 @@ export function ProblemCard({ problem, isFinished, pointsEarned, onClick }: Prob
         )}
 
         {problem.bannerUrl ? (
-          <img src={problem.bannerUrl} alt={problem.title} className="h-full w-full object-cover opacity-80 transition-transform duration-700 group-hover:scale-110" />
+          <img src={problem.bannerUrl} alt={problem.title} className="relative h-full w-full object-cover opacity-80 transition-transform duration-700 group-hover:scale-110" />
         ) : (
           <div className="absolute inset-0 flex items-center justify-center opacity-10"><Terminal size={64} /></div>
         )}
-        <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0b] via-[#0a0a0b]/40 to-transparent z-10" />
+        <div className="absolute inset-x-0 bottom-0 top-auto h-1/3 bg-gradient-to-t from-[#0a0a0b] via-[#0a0a0b]/20 to-transparent z-10" />
         
         <div className="absolute top-5 right-6 flex items-center gap-1.5 z-20">
           <Badge className={cn("px-2.5 py-0.5 font-bold text-[9px] tracking-widest uppercase rounded-lg border shadow-lg", difficultyStyles)}>

--- a/src/pages/ProblemDetailsPage.tsx
+++ b/src/pages/ProblemDetailsPage.tsx
@@ -193,7 +193,7 @@ export function ProblemDetailsPage() {
 
           <div className="absolute inset-0 bg-gradient-to-br from-primary/30 via-purple-900/20 to-transparent z-0" />
           {problem.bannerUrl && (
-            <img src={problem.bannerUrl} alt={problem.title} className="w-full h-auto max-h-80 lg:max-h-125 object-cover mix-blend-overlay opacity-90" />
+            <img src={problem.bannerUrl} alt={problem.title} className="relative w-full h-auto max-h-80 lg:max-h-125 object-cover mix-blend-overlay opacity-90" />
           )}
           <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0b] via-transparent to-transparent z-10" />
           


### PR DESCRIPTION
## 🔗 Task no ClickUp

ID da Task:

## 📝 Descrição das mudanças

Em `ProblemCard.tsx` e `ProblemDetailsPage.tsx`, a `<img>` do banner era um elemento estático (sem `position`), enquanto os dois gradientes decorativos sobre ela são `absolute`. Por regra de empilhamento CSS, conteúdo posicionado sempre pinta por cima de conteúdo estático no mesmo contexto, independente do `z-index` nominal — então os gradientes cobriam a imagem inteira, produzindo uma mancha escura/arroxeada sobre o banner em toda a vitrine de problemas.

Fix: `position: relative` nas duas `<img>`, colocando-as no contexto de empilhamento junto dos gradientes (mantendo a estrutura dos dois `div`s decorativos, sem removê-los). No `ProblemCard.tsx`, o gradiente inferior de contraste do título também teve a área/opacidade reduzida (`inset-0` → concentrado nos 33% finais da altura; opacidade do meio-tom 40% → 20%), já que ao deixar de ficar escondido atrás da imagem ele passou a cobrir a arte de fato — reduzido para dar contraste ao título sem esconder a maior parte do banner.

Closes #40

## 🎯 Tipo de Mudança

- [x] Bug fix (correção de bug)
- [ ] New feature (nova funcionalidade)
- [ ] Documentation (documentação)
- [ ] Refactoring (refatoração)
- [ ] Test (testes)

## 📸 Evidências

Validado visualmente com Playwright/chromium contra um back local com dados de teste (banner real), comparando antes/depois:

- **Card com banner (antes → depois)**: a mancha escura sobre a metade superior do card desaparece; a arte do banner (imagem de código) fica visível, com os badges de dificuldade/pontos legíveis sobre o próprio fundo `bg-black/60` e o título legível na base graças ao gradiente reduzido.
- **Card placeholder (sem banner)**: idêntico ao comportamento atual — ícone de terminal a 10% de opacidade sobre o gradiente roxo de fundo, não tocado por esta mudança.
- **`ProblemDetailsPage` com banner**: o efeito `mix-blend-overlay opacity-90` aparece pela primeira vez de fato (antes ficava atrás dos gradientes) e o resultado ficou visualmente aceitável nos dois temas (claro/escuro) — mantido sem ajuste adicional.

## ✅ Checklist

- [x] Código segue os padrões do projeto
- [x] Self-review foi feito
- [x] Código foi testado localmente (`npm run lint` e `npm run build` passam; validação visual via Playwright/chromium com back local)

## 📌 Notas adicionais

Sem mudança de contrato de API — CSS/JSX puro no frontend, SDK não precisou ser regerado.