### PR TITLE
fix(problemas): remove padding do topo do card que criava barra acima do banner

### DIFF
--- a/src/components/problems/ProblemCard.tsx
+++ b/src/components/problems/ProblemCard.tsx
@@ -40,7 +40,7 @@ export function ProblemCard({ problem, isFinished, pointsEarned, onClick }: Prob
     <Card 
       onClick={handleCardClick}
       className={cn(
-        "group relative aspect-square flex flex-col cursor-pointer overflow-hidden border-white/10 bg-[#0a0a0b]/40 backdrop-blur-xl transition-all duration-500 hover:-translate-y-2 rounded-[32px]",
+        "group relative aspect-square flex flex-col cursor-pointer overflow-hidden border-white/10 bg-[#0a0a0b]/40 backdrop-blur-xl transition-all duration-500 hover:-translate-y-2 rounded-[32px] pt-0",
         isFinished && "border-emerald-500/30 shadow-lg shadow-emerald-500/5"
       )}
     >


### PR DESCRIPTION
## 🔗 Task no ClickUp

ID da Task:

## 📝 Descrição das mudanças

Achado ao validar visualmente o fix da front#40 em produção. O `Card` do shadcn ([app/src/components/ui/card.tsx](../../blob/main/app/src/components/ui/card.tsx)) aplica `py-6` por padrão, e `ProblemCard.tsx` nunca sobrescrevia isso — então o banner sempre ficou 24px abaixo da borda superior real do card, com o fundo translúcido do próprio `Card` (`bg-[#0a0a0b]/40`) preenchendo essa faixa. Antes da front#40 isso era invisível, porque a mancha escura do bug de empilhamento cobria a área inteira do banner e se misturava com esse padding. Com o banner visível de verdade agora, a faixa de padding aparece como uma barra escura separada por cima da arte.

Fix: `pt-0` no `Card` (o `pb-6` do rodapé é preservado via `tailwind-merge`), então o banner passa a colar direto na borda arredondada do topo.

Closes #43

## 🎯 Tipo de Mudança

- [x] Bug fix (correção de bug)
- [ ] New feature (nova funcionalidade)
- [ ] Documentation (documentação)
- [ ] Refactoring (refatoração)
- [ ] Test (testes)

## 📸 Evidências

Validado em produção (`www.ligadealgoritmos.com/problemas`, card "A Fome da Última Fera") isolando camada por camada via DOM: com os gradientes decorativos escondidos, a imagem sozinha já renderizava limpa desde o topo do seu próprio `<div>` — confirmando que a barra vinha do padding do `Card` por cima do banner, não de um gradiente. Comparei visualmente antes/depois com Playwright/chromium contra dados reais: o banner passa a ocupar o topo do card até a borda arredondada, sem faixa de padding, e o espaçamento inferior (título, descrição, "resolvidos") permanece idêntico.

## ✅ Checklist

- [x] Código segue os padrões do projeto
- [x] Self-review foi feito
- [x] Código foi testado localmente (`npm run lint` e `npm run build` passam; validação visual via Playwright/chromium)

## 📌 Notas adicionais

Sem mudança de contrato de API — CSS/JSX puro no frontend, SDK não precisou ser regerado.