### PR TITLE
fix(auth): serializa refresh entre abas (Web Locks) e avisa logout real

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -56,47 +56,85 @@ function clearSession() {
 
 let refreshPromise: Promise<string> | null = null
 
-// Single-flight: requisições concorrentes que tomaram 401 compartilham o mesmo
-// refresh — o backend rotaciona o token, então refreshes paralelos com o mesmo
-// cookie derrubariam a sessão.
+const REFRESH_LOCK_NAME = "auth-refresh"
+const REFRESH_TIMEOUT_MS = 10_000
+
+function hasWebLocks(): boolean {
+  return typeof navigator !== "undefined" && "locks" in navigator && !!navigator.locks
+}
+
+// Executa o refresh de verdade: chamada só depois de garantida a
+// serialização (lock entre abas quando suportado, single-flight por aba
+// sempre). `tokenBeforeRefresh` é o token com que o CHAMADOR entrou na fila —
+// usado para detectar, tanto antes quanto depois da chamada de rede, se outra
+// aba já renovou nesse meio-tempo.
+async function performRefresh(tokenBeforeRefresh: string): Promise<string> {
+  // Reler só agora (após adquirir o lock, se houver): se checasse antes de
+  // entrar na fila, duas abas leriam o mesmo valor "antigo" e chamariam a
+  // rede mesmo assim.
+  const alreadyRenewed = localStorage.getItem(TOKEN_STORAGE_KEY)
+  if (alreadyRenewed && alreadyRenewed !== tokenBeforeRefresh) {
+    setAccessToken(alreadyRenewed)
+    return alreadyRenewed
+  }
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), REFRESH_TIMEOUT_MS)
+
+  try {
+    const res = await rawAxios.post("/auth/refresh", undefined, { signal: controller.signal })
+    const { accessToken: newAccess } = res.data
+
+    setAccessToken(newAccess)
+    localStorage.setItem(TOKEN_STORAGE_KEY, newAccess)
+    return newAccess as string
+  } catch (err) {
+    // Só rejeição real do refresh token encerra a sessão; erro de
+    // rede/5xx/timeout não desloga.
+    if (isAuthError(err)) {
+      const storedToken = localStorage.getItem(TOKEN_STORAGE_KEY)
+
+      // Outra aba renovou enquanto esta esperava a resposta. Como o backend
+      // rotaciona o refresh token, o 401 aqui só significa que perdemos a
+      // corrida — não que a sessão morreu. Adota o token da outra aba: sem
+      // isso, o clearSession() apagaria do localStorage o token que ela
+      // acabou de gravar e o evento `storage` derrubaria todas as abas.
+      if (storedToken && storedToken !== tokenBeforeRefresh) {
+        setAccessToken(storedToken)
+        return storedToken
+      }
+
+      clearSession()
+    }
+    throw err
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+// Single-flight por aba: requisições concorrentes que tomaram 401 na mesma
+// aba compartilham o mesmo refresh. Entre abas do mesmo navegador, o Web Lock
+// em performRefresh garante que só uma efetivamente chama a rede; sem suporte
+// a navigator.locks, cai de volta no single-flight por aba de sempre.
 export function refreshAccessToken(): Promise<string> {
   if (!refreshPromise) {
-    // O single-flight é por aba. Guardamos o token com que ESTA aba entrou na
-    // corrida para saber, num 401, se outra aba renovou nesse meio-tempo.
     const tokenBeforeRefresh = accessToken
 
-    refreshPromise = rawAxios
-      .post("/auth/refresh")
-      .then(res => {
-        const { accessToken: newAccess } = res.data
+    // `LockGrantedCallback<T>` nos tipos do DOM não faz Awaited<T>: como o
+    // callback retorna Promise<string>, o tipo inferido de request() vira
+    // Promise<Promise<string>> — que a Promise nativa de fato achata em
+    // runtime (resolver com um thenable segue o thenable). O cast corrige só
+    // o tipo, não o comportamento.
+    const attempt = hasWebLocks()
+      ? (navigator.locks.request(
+          REFRESH_LOCK_NAME,
+          () => performRefresh(tokenBeforeRefresh)
+        ) as unknown as Promise<string>)
+      : performRefresh(tokenBeforeRefresh)
 
-        setAccessToken(newAccess)
-        localStorage.setItem(TOKEN_STORAGE_KEY, newAccess)
-        return newAccess as string
-      })
-      .catch(err => {
-        // Só rejeição real do refresh token encerra a sessão; erro de
-        // rede/5xx não desloga.
-        if (isAuthError(err)) {
-          const storedToken = localStorage.getItem(TOKEN_STORAGE_KEY)
-
-          // Outra aba renovou enquanto esta esperava a resposta. Como o backend
-          // rotaciona o refresh token, o 401 aqui só significa que perdemos a
-          // corrida — não que a sessão morreu. Adota o token da outra aba: sem
-          // isso, o clearSession() apagaria do localStorage o token que ela
-          // acabou de gravar e o evento `storage` derrubaria todas as abas.
-          if (storedToken && storedToken !== tokenBeforeRefresh) {
-            setAccessToken(storedToken)
-            return storedToken
-          }
-
-          clearSession()
-        }
-        throw err
-      })
-      .finally(() => {
-        refreshPromise = null
-      })
+    refreshPromise = attempt.finally(() => {
+      refreshPromise = null
+    })
   }
   return refreshPromise
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,19 +1,13 @@
 import ReactDOM from 'react-dom/client'
-import { RouterProvider, createRouter } from '@tanstack/react-router'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query' 
+import { RouterProvider } from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Toaster } from 'sonner'
 import { useAuth, AuthProvider } from './providers/AuthProvider'
 import { ThemeProvider } from '@/providers/ThemeProvider'
-import { routeTree } from './routeTree.gen'
+import { router } from './router'
 import './index.css'
 
 const queryClient = new QueryClient()
-
-const router = createRouter({
-  routeTree,
-  context: {
-    auth: undefined!, 
-  },
-})
 
 export function InnerApp() {
   const auth = useAuth()
@@ -32,11 +26,30 @@ export function InnerApp() {
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme"> 
+      <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
         <AuthProvider>
             <InnerApp />
         </AuthProvider>
-      </ThemeProvider> 
+        {/* Montado fora do RouterProvider/loading gate: um toast disparado
+            durante o initAuth() (antes do router montar) precisa de um
+            Toaster já inscrito para não ser descartado (sonner não repassa
+            toasts publicados antes da inscrição a quem assina depois). */}
+        <Toaster
+          richColors
+          position="bottom-right"
+          toastOptions={{
+            style: {
+              borderRadius: 'var(--radius)',
+              fontFamily: 'var(--font-sans)',
+            },
+            classNames: {
+              toast: 'border border-border/20 shadow-xl',
+              title: 'font-semibold text-[15px] tracking-tight',
+              description: 'text-sm opacity-90',
+            }
+          }}
+        />
+      </ThemeProvider>
     </QueryClientProvider>
   )
 }

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useEffect, useCallback, useRef } from "react"
+import { toast } from "sonner"
 import client, {
   setAccessToken,
   setUnauthenticatedHandler,
@@ -6,6 +7,7 @@ import client, {
   isAuthError,
   isTokenExpired,
 } from "@/api/client"
+import { router } from "@/router"
 import { LoginRequestDTO } from "@/api/sdk"
 import UserWithAccount from "@/types/user.types"
 
@@ -81,10 +83,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [fetchUserWithAccount, clearLocalSession])
 
   useEffect(() => {
-    // Dispara quando o refresh token é rejeitado pelo backend. Limpa só esta
+    // Dispara quando o refresh token é rejeitado pelo backend (sessão morta
+    // de verdade — convergência entre abas nunca chama isto). Limpa só esta
     // aba: um /auth/logout aqui derrubaria as outras abas e dispositivos.
     setUnauthenticatedHandler(() => {
       clearLocalSession()
+      toast.warning("Sessão expirada", {
+        description: "Entre novamente para continuar.",
+      })
+      router.navigate({ to: "/login" })
     })
 
     const initAuth = async () => {

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,12 @@
+import { createRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+// Instância própria (fora de main.tsx) para poder navegar de fora da árvore
+// de componentes do RouterProvider — ex. AuthProvider, que é ancestral dele
+// e não tem acesso ao contexto que useNavigate() precisa.
+export const router = createRouter({
+  routeTree,
+  context: {
+    auth: undefined!,
+  },
+})

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,5 +1,4 @@
 import { createRootRouteWithContext, Outlet, useLocation } from '@tanstack/react-router'
-import { Toaster } from 'sonner'
 import { AuthContextType } from '@/providers/AuthProvider'
 import { ThemeProvider } from '@/providers/ThemeProvider'
 import { Navbar } from '@/components/navbar'
@@ -22,22 +21,6 @@ function RootComponent() {
         <main className="flex-1 flex flex-col">
           <Outlet />
         </main>
-        <Toaster 
-          richColors 
-          position="bottom-right" 
-          toastOptions={{
-            style: {
-              borderRadius: 'var(--radius)',
-              fontFamily: 'var(--font-sans)',
-            },
-            classNames: {
-              toast: 'border border-border/20 shadow-xl',
-              title: 'font-semibold text-[15px] tracking-tight',
-              description: 'text-sm opacity-90',
-            }
-          }}
-        />
-
       </div>
     </ThemeProvider>
   )


### PR DESCRIPTION
## 🔗 Task no ClickUp

ID da Task:

## 📝 Descrição das mudanças

Closes #45

Duas abas do mesmo navegador com access token expirando junto disparavam `POST /auth/refresh` cada uma por conta própria — o single-flight de `client.ts` só serializava dentro de uma aba. Como o backend rotaciona o refresh token, a aba que perdia a corrida podia acabar deslogada sem explicação nenhuma.

- `refreshAccessToken()` agora serializa a chamada de rede entre abas via `navigator.locks.request('auth-refresh', ...)`: só uma aba chama `POST /auth/refresh` por vez, e a checagem de "outra aba já renovou?" acontece **depois** de adquirir o lock (checar antes deixaria duas abas lerem o mesmo valor velho). Sem suporte a Web Locks, cai de volta no single-flight por aba de sempre — sem exceção não tratada.
- A chamada de refresh dentro do lock tem timeout de 10s via `AbortController`, para não travar as demais abas esperando indefinidamente por uma requisição pendurada.
- `clearSession()` (sessão morta de verdade — refresh token rejeitado pelo backend, não convergência entre abas) agora dispara um toast (`sonner`, `toast.warning`) via o hook `onUnauthenticated` já existente e redireciona para `/login`, mesmo se o usuário estava parado numa rota protegida quando a sessão morreu.

**Dois ajustes estruturais que a issue não pedia, mas que a implementação exigiu:**
- `useNavigate()` não funciona dentro de `AuthProvider` porque ele é **ancestral** do `RouterProvider` (não descendente) — `useRouter()` faria `useContext` retornar `undefined` e `router.navigate` explodiria em runtime. Extraí a instância do router para [src/router.ts](../../blob/main/src/router.ts) (fora de `main.tsx`) e chamo `router.navigate(...)` diretamente, sem o hook.
- O `<Toaster/>` do sonner vivia dentro do `RouterProvider` (via `__root.tsx`), que só monta depois que `auth.loading` vira `false`. Um toast disparado durante o `initAuth()` (ex.: sessão já morta ao abrir a aba) acontecia **antes** de qualquer `Toaster` estar inscrito — e o sonner não repassa a quem se inscreve depois um toast já publicado. Movi o `<Toaster/>` para `main.tsx`, montado incondicionalmente fora do gate de loading.

Não muda contrato de API — não regenera SDK. Depende opcionalmente da back#51 (tolerar reapresentação do token pai imediato) para o caso de abas em navegadores/dispositivos diferentes, mas não bloqueia este PR (Web Locks já resolve o caso mais comum, abas do mesmo navegador).

## 🎯 Tipo de Mudança

- [x] Bug fix (correção de bug)

## 📸 Evidências

Validado com Playwright (chromium do sistema, `playwright-core`), duas `page` reais no mesmo `browserContext`, contra front+back local (`ACCESS_TOKEN_EXPIRATION="20s"`):

**Duas abas competindo pelo refresh:**
```
[rede] POST /auth/refresh #1
Chamadas de rede a /auth/refresh: 1 (esperado 1)
Tokens convergiram: true (iguais)
Toast na aba 1: 0, aba 2: 0 (esperado 0 nas duas)
RESULTADO: PASS
```

**Fallback sem `navigator.locks`** (removido via `addInitScript` antes do `goto`):
```
navigator.locks disponível na aba 1: false (esperado false)
Chamadas de rede a /auth/refresh: 2 (sem lock, não trava/quebra)
Sessão final consistente (mesmo token nas duas): true
RESULTADO: PASS (fallback não quebra)
```

**Sessão morta de verdade** (refresh token revogado via `POST /auth/logout` direto na API + access token corrompido para forçar nova tentativa de refresh):
```
POST /auth/logout direto na API -> 201
URL final: http://localhost:5173/login (esperado terminar em /login)
Toast: Sessão expiradaEntre novamente para continuar.
accessToken no localStorage: null (esperado vazio)
RESULTADO: PASS
```

`npm run lint` e `npm run build` (`tsc -b && vite build`) passam sem erros.

## ✅ Checklist

- [x] Código segue os padrões do projeto
- [x] Self-review foi feito
- [x] Código foi testado localmente

## 📌 Notas adicionais

Fora de escopo (decisão do dono na issue): preservar a rota em que o usuário estava para voltar após novo login, e rascunho de formulário em andamento — ficam para issue futura se decidido. Timeout do `AbortController` não travar as demais abas foi validado por leitura de código (o `finally` limpa o timeout e libera o lock automaticamente quando a promise do callback resolve/rejeita); simular isso via Playwright exigiria segurar a resposta do back artificialmente e não foi viável nesta rodada.
