### PR TITLE
fix(auth): adapta reset de senha e cadastro ao contrato sem tokenId

### DIFF
--- a/src/api/sdk/api.ts
+++ b/src/api/sdk/api.ts
@@ -653,11 +653,17 @@ export interface ReportBugServiceDTO {
  */
 export interface ResetPasswordDTO {
     /**
-     * Token id
+     * User email
      * @type {string}
      * @memberof ResetPasswordDTO
      */
-    'tokenId': string;
+    'email'?: string;
+    /**
+     * Token id. Deprecated: kept only for backwards compatibility, prefer email.
+     * @type {string}
+     * @memberof ResetPasswordDTO
+     */
+    'tokenId'?: string;
     /**
      * Indicates if the token has 6 digits
      * @type {string}
@@ -691,23 +697,17 @@ export interface ResetPasswordRequestDTO {
  */
 export interface ResetPasswordRequestResponseDTO {
     /**
-     * Reset Password Token ID
+     * Public confirmation message. Identical whether the email has an account or not.
      * @type {string}
      * @memberof ResetPasswordRequestResponseDTO
      */
-    'id': string;
+    'message': string;
     /**
-     * Token expiration date and time
-     * @type {string}
+     * How long the code is valid for, in seconds.
+     * @type {number}
      * @memberof ResetPasswordRequestResponseDTO
      */
-    'expiresAt': string;
-    /**
-     * Indicates whether the token has been revoked
-     * @type {boolean}
-     * @memberof ResetPasswordRequestResponseDTO
-     */
-    'isRevoked': boolean;
+    'expiresInSeconds': number;
 }
 /**
  * 
@@ -779,23 +779,17 @@ export interface SignupRequestDTO {
  */
 export interface SignupRequestResponseDTO {
     /**
-     * Signup Token ID
+     * Public confirmation message. Identical whether the email already has an account or not.
      * @type {string}
      * @memberof SignupRequestResponseDTO
      */
-    'id': string;
+    'message': string;
     /**
-     * Token expiration date and time
-     * @type {string}
+     * How long the code is valid for, in seconds.
+     * @type {number}
      * @memberof SignupRequestResponseDTO
      */
-    'expiresAt': string;
-    /**
-     * Indicates whether the token has been revoked
-     * @type {boolean}
-     * @memberof SignupRequestResponseDTO
-     */
-    'isRevoked': boolean;
+    'expiresInSeconds': number;
 }
 /**
  * 
@@ -1154,11 +1148,17 @@ export type UserResponseDTORoleEnum = typeof UserResponseDTORoleEnum[keyof typeo
  */
 export interface ValidateResetPasswordDTO {
     /**
-     * Token id
+     * User email
      * @type {string}
      * @memberof ValidateResetPasswordDTO
      */
-    'tokenId': string;
+    'email'?: string;
+    /**
+     * Token id. Deprecated: kept only for backwards compatibility, prefer email.
+     * @type {string}
+     * @memberof ValidateResetPasswordDTO
+     */
+    'tokenId'?: string;
     /**
      * Indicates if the token has 6 digits
      * @type {string}
@@ -1173,11 +1173,17 @@ export interface ValidateResetPasswordDTO {
  */
 export interface ValidateSignupDTO {
     /**
-     * Token id
+     * User email
      * @type {string}
      * @memberof ValidateSignupDTO
      */
-    'tokenId': string;
+    'email'?: string;
+    /**
+     * Token id. Deprecated: kept only for backwards compatibility, prefer email.
+     * @type {string}
+     * @memberof ValidateSignupDTO
+     */
+    'tokenId'?: string;
     /**
      * Indicates if the token has 6 digits
      * @type {string}

--- a/src/api/sdk/docs/ResetPasswordApi.md
+++ b/src/api/sdk/docs/ResetPasswordApi.md
@@ -56,7 +56,7 @@ No authorization required
 ### HTTP response details
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
-|**200** | Reset password token created successfully. |  -  |
+|**200** | Always 200, whether or not the email has an account, to avoid leaking which emails are registered. |  -  |
 |**401** | Unauthorized. The provided credentials are invalid. |  -  |
 |**500** | Internal server error. An unexpected error occurred while processing the request. |  -  |
 

--- a/src/api/sdk/docs/ResetPasswordDTO.md
+++ b/src/api/sdk/docs/ResetPasswordDTO.md
@@ -5,7 +5,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**tokenId** | **string** | Token id | [default to undefined]
+**email** | **string** | User email | [optional] [default to undefined]
+**tokenId** | **string** | Token id. Deprecated: kept only for backwards compatibility, prefer email. | [optional] [default to undefined]
 **token** | **string** | Indicates if the token has 6 digits | [default to undefined]
 **newPassword** | **string** | New password for the user | [default to undefined]
 
@@ -15,6 +16,7 @@ Name | Type | Description | Notes
 import { ResetPasswordDTO } from './api';
 
 const instance: ResetPasswordDTO = {
+    email,
     tokenId,
     token,
     newPassword,

--- a/src/api/sdk/docs/ResetPasswordRequestResponseDTO.md
+++ b/src/api/sdk/docs/ResetPasswordRequestResponseDTO.md
@@ -5,9 +5,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **string** | Reset Password Token ID | [default to undefined]
-**expiresAt** | **string** | Token expiration date and time | [default to undefined]
-**isRevoked** | **boolean** | Indicates whether the token has been revoked | [default to undefined]
+**message** | **string** | Public confirmation message. Identical whether the email has an account or not. | [default to undefined]
+**expiresInSeconds** | **number** | How long the code is valid for, in seconds. | [default to undefined]
 
 ## Example
 
@@ -15,9 +14,8 @@ Name | Type | Description | Notes
 import { ResetPasswordRequestResponseDTO } from './api';
 
 const instance: ResetPasswordRequestResponseDTO = {
-    id,
-    expiresAt,
-    isRevoked,
+    message,
+    expiresInSeconds,
 };
 ```
 

--- a/src/api/sdk/docs/SignupApi.md
+++ b/src/api/sdk/docs/SignupApi.md
@@ -55,7 +55,7 @@ No authorization required
 ### HTTP response details
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
-|**200** | User signed up successfully. |  -  |
+|**200** | Always 200, whether or not the email already has an account, to avoid leaking which emails are registered. |  -  |
 |**401** | Unauthorized. The provided credentials are invalid. |  -  |
 |**500** | Internal server error. An unexpected error occurred while processing the request. |  -  |
 

--- a/src/api/sdk/docs/SignupRequestResponseDTO.md
+++ b/src/api/sdk/docs/SignupRequestResponseDTO.md
@@ -5,9 +5,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **string** | Signup Token ID | [default to undefined]
-**expiresAt** | **string** | Token expiration date and time | [default to undefined]
-**isRevoked** | **boolean** | Indicates whether the token has been revoked | [default to undefined]
+**message** | **string** | Public confirmation message. Identical whether the email already has an account or not. | [default to undefined]
+**expiresInSeconds** | **number** | How long the code is valid for, in seconds. | [default to undefined]
 
 ## Example
 
@@ -15,9 +14,8 @@ Name | Type | Description | Notes
 import { SignupRequestResponseDTO } from './api';
 
 const instance: SignupRequestResponseDTO = {
-    id,
-    expiresAt,
-    isRevoked,
+    message,
+    expiresInSeconds,
 };
 ```
 

--- a/src/api/sdk/docs/ValidateResetPasswordDTO.md
+++ b/src/api/sdk/docs/ValidateResetPasswordDTO.md
@@ -5,7 +5,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**tokenId** | **string** | Token id | [default to undefined]
+**email** | **string** | User email | [optional] [default to undefined]
+**tokenId** | **string** | Token id. Deprecated: kept only for backwards compatibility, prefer email. | [optional] [default to undefined]
 **token** | **string** | Indicates if the token has 6 digits | [default to undefined]
 
 ## Example
@@ -14,6 +15,7 @@ Name | Type | Description | Notes
 import { ValidateResetPasswordDTO } from './api';
 
 const instance: ValidateResetPasswordDTO = {
+    email,
     tokenId,
     token,
 };

--- a/src/api/sdk/docs/ValidateSignupDTO.md
+++ b/src/api/sdk/docs/ValidateSignupDTO.md
@@ -5,7 +5,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**tokenId** | **string** | Token id | [default to undefined]
+**email** | **string** | User email | [optional] [default to undefined]
+**tokenId** | **string** | Token id. Deprecated: kept only for backwards compatibility, prefer email. | [optional] [default to undefined]
 **token** | **string** | Indicates if the token has 6 digits | [default to undefined]
 
 ## Example
@@ -14,6 +15,7 @@ Name | Type | Description | Notes
 import { ValidateSignupDTO } from './api';
 
 const instance: ValidateSignupDTO = {
+    email,
     tokenId,
     token,
 };

--- a/src/components/ForgotPasswordModal.tsx
+++ b/src/components/ForgotPasswordModal.tsx
@@ -35,7 +35,7 @@ const emailSchema = z.object({
 })
 
 const passwordSchema = z.object({
-  password: z.string().min(6, "A senha deve ter no mínimo 8 caracteres")
+  password: z.string()
     .min(9, "A senha deve ter mais de 8 caracteres.")
     .regex(/[A-Z]/, "Deve conter letra maiúscula.")
     .regex(/[a-z]/, "Deve conter letra minúscula.")
@@ -328,6 +328,20 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
                 disabled={isLoading}
               >
                 {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : "Redefinir Senha"}
+              </Button>
+
+              {/* Sem isto o passo e um beco sem saida: se o codigo expirar ou
+                  esgotar as tentativas entre a validacao e o envio da senha, o
+                  back recusa e a unica saida seria fechar o modal e recomecar.
+                  Voltar devolve o acesso ao "Reenviar codigo". */}
+              <Button
+                type="button"
+                variant="ghost"
+                className="w-full h-11 text-muted-foreground hover:text-foreground hover:bg-muted/50 cursor-pointer"
+                onClick={() => setStep("OTP")}
+                disabled={isLoading}
+              >
+                <ArrowLeft className="mr-2 h-4 w-4" /> Voltar
               </Button>
             </form>
           )}

--- a/src/components/ForgotPasswordModal.tsx
+++ b/src/components/ForgotPasswordModal.tsx
@@ -21,11 +21,14 @@ import {
   InputOTPGroup,
   InputOTPSlot,
 } from "@/components/ui/input-otp"
-import { useCountdown, formatCountdown } from "@/hooks/use-countdown"
+import { useCountdown, formatCountdown, countdownWindowMs } from "@/hooks/use-countdown"
 import { otpErrorDescription } from "@/lib/otp-messages"
 
 const OTP_LENGTH = 6
 const RESEND_COOLDOWN_SECONDS = 30
+// Espelha o RESET_TOKEN_EXPIRES_IN_SECONDS do back; so entra em cena se o
+// `expiresInSeconds` da resposta faltar.
+const RESET_CODE_FALLBACK_SECONDS = 15 * 60
 
 const emailSchema = z.object({
   email: z.string().email("Insira um email válido"),
@@ -75,7 +78,7 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
 
   const startOtpWindow = (expiresInSeconds: number) => {
     const startedAt = Date.now()
-    setExpiresAtMs(startedAt + expiresInSeconds * 1000)
+    setExpiresAtMs(startedAt + countdownWindowMs(expiresInSeconds, RESET_CODE_FALLBACK_SECONDS))
     setResendAvailableAt(startedAt + RESEND_COOLDOWN_SECONDS * 1000)
     setOtp("")
     setOtpFailures(0)

--- a/src/components/ForgotPasswordModal.tsx
+++ b/src/components/ForgotPasswordModal.tsx
@@ -22,6 +22,7 @@ import {
   InputOTPSlot,
 } from "@/components/ui/input-otp"
 import { useCountdown, formatCountdown } from "@/hooks/use-countdown"
+import { otpErrorDescription } from "@/lib/otp-messages"
 
 const OTP_LENGTH = 6
 const RESEND_COOLDOWN_SECONDS = 30
@@ -54,8 +55,8 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
   const [step, setStep] = useState<Step>("EMAIL")
   const [isLoading, setIsLoading] = useState(false)
   const [isResending, setIsResending] = useState(false)
-  const [tokenId, setTokenId] = useState("")
   const [otp, setOtp] = useState("")
+  const [otpFailures, setOtpFailures] = useState(0)
   const [email, setEmail] = useState("")
   const [expiresAtMs, setExpiresAtMs] = useState<number | null>(null)
   const [resendAvailableAt, setResendAvailableAt] = useState<number | null>(null)
@@ -72,11 +73,12 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
     resolver: zodResolver(passwordSchema),
   })
 
-  const startOtpWindow = (newTokenId: string, newExpiresAt: string) => {
-    setTokenId(newTokenId)
-    setExpiresAtMs(new Date(newExpiresAt).getTime())
-    setResendAvailableAt(Date.now() + RESEND_COOLDOWN_SECONDS * 1000)
+  const startOtpWindow = (expiresInSeconds: number) => {
+    const startedAt = Date.now()
+    setExpiresAtMs(startedAt + expiresInSeconds * 1000)
+    setResendAvailableAt(startedAt + RESEND_COOLDOWN_SECONDS * 1000)
     setOtp("")
+    setOtpFailures(0)
   }
 
   const handleRequestReset = async (data: z.infer<typeof emailSchema>) => {
@@ -86,12 +88,12 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
         email: data.email,
       })
 
-      if (response.data.id) {
-        startOtpWindow(response.data.id, response.data.expiresAt)
-        setEmail(data.email)
-        setStep("OTP")
-        toast.success("Código enviado!", { description: "Verifique sua caixa de entrada." })
-      }
+      startOtpWindow(response.data.expiresInSeconds)
+      setEmail(data.email)
+      setStep("OTP")
+      toast.success("Se este e-mail estiver cadastrado, enviamos um código.", {
+        description: "Verifique sua caixa de entrada.",
+      })
     } catch (error) {
       console.error(error)
       toast.error("Erro ao solicitar recuperação", { description: "Verifique o email e tente novamente." })
@@ -107,10 +109,10 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
         email,
       })
 
-      if (response.data.id) {
-        startOtpWindow(response.data.id, response.data.expiresAt)
-        toast.success("Novo código enviado!", { description: "O código anterior deixou de ser válido." })
-      }
+      startOtpWindow(response.data.expiresInSeconds)
+      toast.success("Se este e-mail estiver cadastrado, enviamos um novo código.", {
+        description: "Qualquer código anterior deixou de ser válido.",
+      })
     } catch (error) {
       console.error(error)
       toast.error("Erro ao reenviar código", { description: "Tente novamente em instantes." })
@@ -124,7 +126,7 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
     setIsLoading(true)
     try {
       await client.resetPassword.resetPasswordControllerValidateResetPassword({
-        tokenId: tokenId,
+        email,
         token: otp,
       })
 
@@ -132,8 +134,10 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
       toast.success("Código validado!")
     } catch (error) {
       console.error(error)
+      const failures = otpFailures + 1
+      setOtpFailures(failures)
       setOtp("")
-      toast.error("Código inválido", { description: "Tente novamente." })
+      toast.error("Código inválido", { description: otpErrorDescription(failures) })
     } finally {
       setIsLoading(false)
     }
@@ -143,7 +147,7 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
     setIsLoading(true)
     try {
       await client.resetPassword.resetPasswordControllerResetPassword({
-        tokenId: tokenId,
+        email,
         token: otp,
         newPassword: data.password,
       })
@@ -163,6 +167,7 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
     setTimeout(() => {
       setStep("EMAIL")
       setOtp("")
+      setOtpFailures(0)
       setExpiresAtMs(null)
       setResendAvailableAt(null)
       emailForm.reset()
@@ -177,7 +182,7 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
           <DialogTitle className="text-foreground">Recuperar Senha</DialogTitle>
           <DialogDescription className="text-muted-foreground">
             {step === "EMAIL" && "Insira seu email para receber o código de recuperação."}
-            {step === "OTP" && `Enviamos um código de 6 dígitos para ${email}.`}
+            {step === "OTP" && `Se ${email} tiver uma conta, enviamos um código de 6 dígitos.`}
             {step === "NEW_PASSWORD" && "Crie uma nova senha segura para sua conta."}
           </DialogDescription>
         </DialogHeader>

--- a/src/components/ForgotPasswordModal.tsx
+++ b/src/components/ForgotPasswordModal.tsx
@@ -22,7 +22,7 @@ import {
   InputOTPSlot,
 } from "@/components/ui/input-otp"
 import { useCountdown, formatCountdown, countdownWindowMs } from "@/hooks/use-countdown"
-import { otpErrorDescription } from "@/lib/otp-messages"
+import { otpErrorDescription, isCodeRejection } from "@/lib/otp-messages"
 
 const OTP_LENGTH = 6
 const RESEND_COOLDOWN_SECONDS = 30
@@ -137,6 +137,12 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
       toast.success("Código validado!")
     } catch (error) {
       console.error(error)
+      if (!isCodeRejection(error)) {
+        toast.error("Não foi possível verificar o código", {
+          description: "Verifique sua conexão e tente novamente.",
+        })
+        return
+      }
       const failures = otpFailures + 1
       setOtpFailures(failures)
       setOtp("")
@@ -159,7 +165,11 @@ export function ForgotPasswordModal({ isOpen, onOpenChange }: ForgotPasswordModa
       handleClose()
     } catch (error) {
       console.error(error)
-      toast.error("Erro ao alterar senha")
+      toast.error("Erro ao alterar senha", {
+        description: isCodeRejection(error)
+          ? "O código pode ter expirado. Volte e peça um novo."
+          : "Verifique sua conexão e tente novamente.",
+      })
     } finally {
       setIsLoading(false)
     }

--- a/src/components/signup/SignupForm.tsx
+++ b/src/components/signup/SignupForm.tsx
@@ -9,7 +9,6 @@ import client from "@/api/client"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { SignupRequestResponseDTO } from "@/api/sdk"
 
 const formSchema = z.object({
   name: z.string().min(2, "O nome deve ter pelo menos 2 caracteres."),
@@ -17,7 +16,7 @@ const formSchema = z.object({
     .email("Endereço de email inválido.")
     .regex(/^[a-zA-Z0-9._%+-]+@(?:[a-zA-Z0-9-]+\.)?pucrs\.br$/i, "Deve ser um email acadêmico PUCRS"),
   password: z.string()
-    .min(8, "A senha deve ter no mínimo 8 caracteres.")
+    .min(9, "A senha deve ter mais de 8 caracteres.")
     .regex(/[A-Z]/, "Deve conter letra maiúscula.")
     .regex(/[a-z]/, "Deve conter letra minúscula.")
     .regex(/\d/, "Deve conter um número.")
@@ -26,7 +25,7 @@ const formSchema = z.object({
 
 type FormValues = z.infer<typeof formSchema>
 
-export function SignupForm({ onSuccess }: { onSuccess: (response: SignupRequestResponseDTO, credentials: FormValues) => void }) {
+export function SignupForm({ onSuccess }: { onSuccess: (expiresInSeconds: number, credentials: FormValues) => void }) {
   const navigate = useNavigate()
 
   const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<FormValues>({
@@ -37,12 +36,10 @@ export function SignupForm({ onSuccess }: { onSuccess: (response: SignupRequestR
   async function onSubmit(values: FormValues) {
     try {
       const { data } = await client.signup.signupControllerValidateSignup(values)
-      if (data.id) {
-        toast.success("Conta criada com sucesso!", {
-            description: "Enviamos um código para o seu email."
-        })
-        onSuccess(data, values)
-      }
+      toast.success("Se este e-mail estiver disponível, enviamos um código.", {
+          description: "Verifique a sua caixa de entrada."
+      })
+      onSuccess(data.expiresInSeconds, values)
     } catch (error) {
       console.log(error)
       toast.error("Erro ao criar conta", { 

--- a/src/components/signup/ValidateSignup.tsx
+++ b/src/components/signup/ValidateSignup.tsx
@@ -11,7 +11,7 @@ import {
   InputOTPSlot,
 } from "@/components/ui/input-otp"
 import { useCountdown, formatCountdown, countdownWindowMs } from "@/hooks/use-countdown"
-import { otpErrorDescription } from "@/lib/otp-messages"
+import { otpErrorDescription, isCodeRejection } from "@/lib/otp-messages"
 
 const OTP_LENGTH = 6
 const RESEND_COOLDOWN_SECONDS = 30
@@ -60,6 +60,12 @@ export function ValidateSignup({ expiresAtMs: initialExpiresAtMs, credentials, o
       navigate({ to: "/login" })
     } catch (err) {
       console.error(err)
+      if (!isCodeRejection(err)) {
+        toast.error("Não foi possível verificar o código", {
+          description: "Verifique a sua ligação e tente novamente.",
+        })
+        return
+      }
       const failures = otpFailures + 1
       setOtpFailures(failures)
       setOtp("")

--- a/src/components/signup/ValidateSignup.tsx
+++ b/src/components/signup/ValidateSignup.tsx
@@ -10,11 +10,14 @@ import {
   InputOTPGroup,
   InputOTPSlot,
 } from "@/components/ui/input-otp"
-import { useCountdown, formatCountdown } from "@/hooks/use-countdown"
+import { useCountdown, formatCountdown, countdownWindowMs } from "@/hooks/use-countdown"
 import { otpErrorDescription } from "@/lib/otp-messages"
 
 const OTP_LENGTH = 6
 const RESEND_COOLDOWN_SECONDS = 30
+// Espelha o SIGNUP_TOKEN_EXPIRES_IN_SECONDS do back; so entra em cena se o
+// `expiresInSeconds` da resposta faltar.
+export const SIGNUP_CODE_FALLBACK_SECONDS = 10 * 60
 
 export interface SignupCredentials {
   name: string
@@ -73,7 +76,7 @@ export function ValidateSignup({ expiresAtMs: initialExpiresAtMs, credentials, o
     try {
       const { data } = await client.signup.signupControllerValidateSignup(credentials)
       const resentAt = Date.now()
-      setExpiresAtMs(resentAt + data.expiresInSeconds * 1000)
+      setExpiresAtMs(resentAt + countdownWindowMs(data.expiresInSeconds, SIGNUP_CODE_FALLBACK_SECONDS))
       setResendAvailableAt(resentAt + RESEND_COOLDOWN_SECONDS * 1000)
       setOtp("")
       setOtpFailures(0)

--- a/src/components/signup/ValidateSignup.tsx
+++ b/src/components/signup/ValidateSignup.tsx
@@ -11,6 +11,7 @@ import {
   InputOTPSlot,
 } from "@/components/ui/input-otp"
 import { useCountdown, formatCountdown } from "@/hooks/use-countdown"
+import { otpErrorDescription } from "@/lib/otp-messages"
 
 const OTP_LENGTH = 6
 const RESEND_COOLDOWN_SECONDS = 30
@@ -22,18 +23,17 @@ export interface SignupCredentials {
 }
 
 interface ValidateSignupProps {
-  tokenId: string
-  expiresAt: string
+  expiresAtMs: number
   credentials: SignupCredentials
   onBack: () => void
 }
 
-export function ValidateSignup({ tokenId: initialTokenId, expiresAt: initialExpiresAt, credentials, onBack }: ValidateSignupProps) {
+export function ValidateSignup({ expiresAtMs: initialExpiresAtMs, credentials, onBack }: ValidateSignupProps) {
   const [otp, setOtp] = useState("")
   const [isLoading, setIsLoading] = useState(false)
   const [isResending, setIsResending] = useState(false)
-  const [tokenId, setTokenId] = useState(initialTokenId)
-  const [expiresAtMs, setExpiresAtMs] = useState(() => new Date(initialExpiresAt).getTime())
+  const [otpFailures, setOtpFailures] = useState(0)
+  const [expiresAtMs, setExpiresAtMs] = useState(initialExpiresAtMs)
   const [resendAvailableAt, setResendAvailableAt] = useState(() => Date.now() + RESEND_COOLDOWN_SECONDS * 1000)
   const navigate = useNavigate()
 
@@ -47,7 +47,7 @@ export function ValidateSignup({ tokenId: initialTokenId, expiresAt: initialExpi
     setIsLoading(true)
     try {
       await client.signup.signupControllerValidateToken({
-        tokenId: tokenId,
+        email: credentials.email,
         token: otp,
       })
 
@@ -57,9 +57,11 @@ export function ValidateSignup({ tokenId: initialTokenId, expiresAt: initialExpi
       navigate({ to: "/login" })
     } catch (err) {
       console.error(err)
+      const failures = otpFailures + 1
+      setOtpFailures(failures)
       setOtp("")
       toast.error("Código inválido", {
-        description: "O código inserido está incorreto. Tente novamente.",
+        description: otpErrorDescription(failures),
       })
     } finally {
       setIsLoading(false)
@@ -70,11 +72,14 @@ export function ValidateSignup({ tokenId: initialTokenId, expiresAt: initialExpi
     setIsResending(true)
     try {
       const { data } = await client.signup.signupControllerValidateSignup(credentials)
-      setTokenId(data.id)
-      setExpiresAtMs(new Date(data.expiresAt).getTime())
-      setResendAvailableAt(Date.now() + RESEND_COOLDOWN_SECONDS * 1000)
+      const resentAt = Date.now()
+      setExpiresAtMs(resentAt + data.expiresInSeconds * 1000)
+      setResendAvailableAt(resentAt + RESEND_COOLDOWN_SECONDS * 1000)
       setOtp("")
-      toast.success("Novo código enviado!", { description: "O código anterior deixou de ser válido." })
+      setOtpFailures(0)
+      toast.success("Se este e-mail estiver disponível, enviamos um novo código.", {
+        description: "Qualquer código anterior deixou de ser válido.",
+      })
     } catch (err) {
       console.error(err)
       toast.error("Erro ao reenviar código", { description: "Tente novamente em instantes." })
@@ -93,7 +98,7 @@ export function ValidateSignup({ tokenId: initialTokenId, expiresAt: initialExpi
         </div>
         <h2 className="text-xl font-semibold">Verifique o seu email</h2>
         <p className="text-sm text-muted-foreground max-w-xs mx-auto">
-          Enviámos um código de 6 dígitos para o seu email. Insira-o abaixo para continuar.
+          Se {credentials.email} estiver disponível, enviámos um código de 6 dígitos. Insira-o abaixo para continuar.
         </p>
       </div>
 

--- a/src/hooks/use-countdown.ts
+++ b/src/hooks/use-countdown.ts
@@ -5,8 +5,19 @@ export function useCountdown(targetTimestamp: number | null) {
 
   useEffect(() => {
     if (!targetTimestamp) return
-    const interval = setInterval(() => setNow(Date.now()), 1000)
-    return () => clearInterval(interval)
+    const tick = () => setNow(Date.now())
+    // `now` foi capturado no mount do componente, entao ja esta velho quando um
+    // alvo novo chega (o modal de recuperacao, por exemplo, fica montado desde
+    // que a tela de login carregou). Sem este primeiro tick o contador exibe a
+    // janela somada ao tempo parado — "15:01" em vez de "15:00" — ate o
+    // setInterval corrigir 1s depois. O setTimeout(0) e o que mantem o setState
+    // fora do corpo do efeito, que a regra set-state-in-effect proibe.
+    const firstTick = setTimeout(tick, 0)
+    const interval = setInterval(tick, 1000)
+    return () => {
+      clearTimeout(firstTick)
+      clearInterval(interval)
+    }
   }, [targetTimestamp])
 
   if (!targetTimestamp) return 0

--- a/src/hooks/use-countdown.ts
+++ b/src/hooks/use-countdown.ts
@@ -24,6 +24,23 @@ export function useCountdown(targetTimestamp: number | null) {
   return Math.max(0, Math.ceil((targetTimestamp - now) / 1000))
 }
 
+/**
+ * Milissegundos de janela a partir do `expiresInSeconds` da resposta, caindo no
+ * fallback quando o campo nao vier utilizavel. Os dois fluxos acabaram de
+ * quebrar por confiar num campo de resposta que sumiu do contrato, e aqui a
+ * queda seria pior: `Date.now() + undefined * 1000` da `NaN`, o `useCountdown`
+ * trata `NaN` como "sem alvo" e devolve 0, e a tela nasce com o campo de codigo
+ * ja desabilitado e "Codigo expirado" — sem deixar sequer digitar. Com o
+ * fallback, o pior caso vira um contador impreciso.
+ */
+export function countdownWindowMs(expiresInSeconds: number | undefined, fallbackSeconds: number) {
+  const seconds =
+    typeof expiresInSeconds === "number" && Number.isFinite(expiresInSeconds) && expiresInSeconds > 0
+      ? expiresInSeconds
+      : fallbackSeconds
+  return seconds * 1000
+}
+
 export function formatCountdown(totalSeconds: number) {
   const minutes = Math.floor(totalSeconds / 60)
   const seconds = totalSeconds % 60

--- a/src/lib/otp-messages.ts
+++ b/src/lib/otp-messages.ts
@@ -1,0 +1,14 @@
+const OTP_FAILURES_BEFORE_HINT = 3
+
+/**
+ * Descricao do toast de codigo invalido. O back responde a mesma mensagem para
+ * codigo errado, expirado, revogado ou tentativas esgotadas (de proposito, para
+ * nao vazar o motivo), entao o front conta as falhas localmente e, a partir da
+ * terceira, sugere pedir um codigo novo — que e o unico caminho depois das 5
+ * tentativas que o back permite por token.
+ */
+export function otpErrorDescription(failures: number) {
+  return failures >= OTP_FAILURES_BEFORE_HINT
+    ? "Confira o código recebido ou peça um novo — após algumas tentativas o código deixa de valer."
+    : "Tente novamente."
+}

--- a/src/lib/otp-messages.ts
+++ b/src/lib/otp-messages.ts
@@ -1,3 +1,5 @@
+import { isAxiosError } from "axios"
+
 const OTP_FAILURES_BEFORE_HINT = 3
 
 /**
@@ -11,4 +13,18 @@ export function otpErrorDescription(failures: number) {
   return failures >= OTP_FAILURES_BEFORE_HINT
     ? "Confira o código recebido ou peça um novo — após algumas tentativas o código deixa de valer."
     : "Tente novamente."
+}
+
+/**
+ * O back chegou a julgar o codigo, ou o pedido nem chegou la? Rede caida, 5xx e
+ * o 429 do ThrottlerGuard nao dizem nada sobre o que foi digitado — contar isso
+ * como codigo errado faz o front acusar "Codigo invalido", limpar o campo e
+ * sugerir pedir um novo por causa de uma queda de ligacao, alem de descolar a
+ * contagem local das 5 tentativas que o back registra no token.
+ */
+export function isCodeRejection(error: unknown): boolean {
+  if (!isAxiosError(error)) return false
+  const status = error.response?.status
+  if (status === undefined || status === 429 || status >= 500) return false
+  return true
 }

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -4,15 +4,14 @@ import { Rocket, Trophy, Users, Code2 } from "lucide-react"
 
 import { SignupForm } from "@/components/signup/SignupForm"
 import { ValidateSignup, type SignupCredentials } from "@/components/signup/ValidateSignup"
-import { SignupRequestResponseDTO } from "@/api/sdk"
 
 export default function SignupPage() {
   const [step, setStep] = useState<1 | 2>(1)
-  const [signupResponse, setSignupResponse] = useState<SignupRequestResponseDTO | null>(null)
+  const [expiresAtMs, setExpiresAtMs] = useState<number | null>(null)
   const [credentials, setCredentials] = useState<SignupCredentials | null>(null)
 
-  const handleSignupSuccess = (response: SignupRequestResponseDTO, values: SignupCredentials) => {
-    setSignupResponse(response)
+  const handleSignupSuccess = (expiresInSeconds: number, values: SignupCredentials) => {
+    setExpiresAtMs(Date.now() + expiresInSeconds * 1000)
     setCredentials(values)
     setStep(2)
   }
@@ -83,12 +82,11 @@ export default function SignupPage() {
                         </p>
                     </div>
 
-                    {step === 1 || !signupResponse || !credentials ? (
+                    {step === 1 || expiresAtMs === null || !credentials ? (
                         <SignupForm onSuccess={handleSignupSuccess} />
                     ) : (
                         <ValidateSignup
-                            tokenId={signupResponse.id}
-                            expiresAt={signupResponse.expiresAt}
+                            expiresAtMs={expiresAtMs}
                             credentials={credentials}
                             onBack={() => setStep(1)}
                         />

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -3,7 +3,12 @@ import { useState } from "react"
 import { Rocket, Trophy, Users, Code2 } from "lucide-react"
 
 import { SignupForm } from "@/components/signup/SignupForm"
-import { ValidateSignup, type SignupCredentials } from "@/components/signup/ValidateSignup"
+import {
+  ValidateSignup,
+  SIGNUP_CODE_FALLBACK_SECONDS,
+  type SignupCredentials,
+} from "@/components/signup/ValidateSignup"
+import { countdownWindowMs } from "@/hooks/use-countdown"
 
 export default function SignupPage() {
   const [step, setStep] = useState<1 | 2>(1)
@@ -11,7 +16,7 @@ export default function SignupPage() {
   const [credentials, setCredentials] = useState<SignupCredentials | null>(null)
 
   const handleSignupSuccess = (expiresInSeconds: number, values: SignupCredentials) => {
-    setExpiresAtMs(Date.now() + expiresInSeconds * 1000)
+    setExpiresAtMs(Date.now() + countdownWindowMs(expiresInSeconds, SIGNUP_CODE_FALLBACK_SECONDS))
     setCredentials(values)
     setStep(2)
   }


### PR DESCRIPTION
## 🔗 Task no ClickUp

<!-- Informe aqui o ID da task relacionada no ClickUp -->

ID da Task:

## 📝 Descrição das mudanças

Closes #48. Par do [back#23](https://github.com/Liga-de-Algoritmos-PUCRS/liga-platform-backend/issues/23) (PR back#57, já mergeado e em produção).

**Não é uma adaptação preventiva — é conserto de uma quebra ativa.** A retrocompat do `tokenId` que o back manteve cobre o **corpo da requisição**, não o **corpo da resposta**, e é da resposta que o front dependia para sequer trocar de tela. Desde o deploy do back#57, `POST /reset-password/request` e `POST /signup` respondem `{ message, expiresInSeconds }` — sem `id`, sem `expiresAt`. O front testava `if (data.id)`, que passou a ser sempre falso: **nenhum aluno consegue criar conta nem recuperar senha**, e sem nem um toast de erro, porque nada é lançado.

O que muda:

- **Avança por sucesso HTTP, não por conteúdo da resposta.** O contrato novo é deliberadamente vazio de sinal; a condição correta é "não lançou".
- **Expiração vem de `expiresInSeconds`**, convertida para timestamp absoluto no próprio handler (`Date.now() + expiresInSeconds * 1000`), nunca no corpo do componente — `react-hooks/purity`.
- **`validate`/`reset`/`signup/validate` passam `{ email, token }`**, sem `tokenId`. Os dois campos são mutuamente exclusivos no back (`@NotTogetherWith`); mandar os dois é 400, e o SDK deixa ambos opcionais, então isso é invariante de revisão, não de tipo.
- **Os textos deixaram de afirmar que o e-mail existe.** O back parou de afirmar; o front não pode afirmar no lugar dele. "Conta criada com sucesso!" e "Código enviado!" viraram formas condicionais.
- **Toast de código inválido fica progressivo.** O back responde a mesma frase para código errado, expirado, revogado e tentativas esgotadas (de propósito). Como ele revoga o token após 5 tentativas — quando nem o código certo passa mais —, o front conta as falhas localmente e a partir da 3ª sugere pedir um novo código.
- **Zod da senha do cadastro alinhado ao back** (`> 8` caracteres). O front aceitava 8 e o back devolvia 400 genérico.
- **Bônus fora da lista original de arquivos:** `useCountdown` só atualizava o `now` 1s depois de receber um alvo novo, então o primeiro paint somava a janela ao tempo que o componente já estava montado — o modal de recuperação vive desde que a tela de login carregou e exibia **"15:01"** (ou mais, conforme o tempo parado ali) por um segundo. Como "contador correto" é critério de aceite da issue, entrou aqui. O hook só é usado por estes dois fluxos.

## 🎯 Tipo de Mudança

- [x] Bug fix (correção de bug)
- [ ] New feature (nova funcionalidade)
- [ ] Documentation (documentação)
- [ ] Refactoring (refatoração)
- [ ] Test (testes)

## 📸 Evidências

Não há infraestrutura de teste no projeto: validação por Playwright (`chromium` do sistema) contra **back local** rodando o código de `origin/main` (nunca produção), com banco Postgres descartável e credenciais AWS neutralizadas. **49 asserções, nenhuma falha.**

### Antes (worktree em `origin/main`, o código que a Vercel serve hoje)

```
=== FLUXO 1: RESET DE SENHA (antes) ===
  clicando "Enviar Código"...
  toasts após Enviar Código: (NENHUM)
  campo de e-mail ainda visível? true
  campo OTP visível? false
  descrição do modal: Insira seu email para receber o código de recuperação.

=== FLUXO 2: CADASTRO (antes) ===
  clicando "Criar Conta"...
  toasts após Criar Conta: (NENHUM)
  título da tela: Crie a sua conta
  ainda no formulário (campo #name visível)? true

=== requisições observadas ===
  POST /reset-password/request -> 200 {"message":"If this email exists, a code has been sent.","expiresInSeconds":900}
  POST /signup -> 200 {"message":"If this email is available, we sent a verification code.","expiresInSeconds":600}
```

As duas requisições voltam **200** e a tela não muda. É a quebra silenciosa.

### Depois — cadastro ponta a ponta

```
-- Q9: senha de 8 caracteres barrada no proprio formulario --
  ✅ erro exibido no form: ["A senha deve ter mais de 8 caracteres."]
  ✅ nao avancou de tela

-- signup valido --
  toast: Se este e-mail estiver disponível, enviamos um código. | Verifique a sua caixa de entrada.
  ✅ toast nao afirma que a conta foi criada
  ✅ sumiu o "Conta criada com sucesso!"
  descricao: Se depois.cadastro@edu.pucrs.br estiver disponível, enviámos um código de 6 dígitos. Insira-o abaixo para continuar.
  ✅ descricao condicional
  countdown: Código expira em 10:00
  ✅ countdown comeca em ~10:00 (600s)
  countdown +2.5s: Código expira em 9:58
  ✅ countdown regride de 1 em 1s

-- Q6: toast progressivo de codigo invalido --
  falha 1: Código inválido | Tente novamente.
  falha 2: Código inválido | Tente novamente.
  falha 3: Código inválido | Confira o código recebido ou peça um novo — após algumas tentativas o código deixa de valer.
  ✅ 3a falha sugere pedir novo codigo

-- reenvio --
  ✅ reenvio bloqueado no cooldown (botao: "Reenviar código (12s)")
  toast: Se este e-mail estiver disponível, enviamos um novo código. | Qualquer código anterior deixou de ser válido.
  ✅ token novo emitido (478473 -> 242405)
  ✅ token anterior is_revoked=t
  countdown apos reenvio: Código expira em 10:00 -> +2.5s: Código expira em 9:58
  ✅ codigo antigo (revogado) recusado

-- codigo novo cria a conta --
  URL: http://localhost:5173/login
  toast: Conta verificada com sucesso! | Você já pode fazer o seu login.
  ✅ conta existe no banco
  ✅ login funciona com a senha do cadastro

-- Q5: signup com e-mail JA cadastrado --
  toasts: ["Se este e-mail estiver disponível, enviamos um código. | Verifique a sua caixa de entrada."]
  ✅ avanca para a mesma tela de codigo
  ✅ nenhum texto denuncia que a conta existe
  ✅ nenhum token novo criado (2 -> 2)
```

### Depois — reset de senha ponta a ponta

```
  toast: Se este e-mail estiver cadastrado, enviamos um código. | Verifique sua caixa de entrada.
  ✅ toast condicional, nao afirma que o e-mail existe
  ✅ sumiu o "Código enviado!" afirmativo
  descricao: Se depois.cadastro@edu.pucrs.br tiver uma conta, enviamos um código de 6 dígitos.
  countdown: ["Código expira em 15:00"] -> +2.5s: ["Código expira em 14:58"]
  ✅ countdown comeca em ~15:00 (900s)

-- reenvio --
  ✅ token novo emitido (442105 -> 281457)
  ✅ token anterior revogado
  ✅ codigo antigo recusado

-- validar e trocar a senha --
  toast: Código validado!  ->  Senha alterada com sucesso! | Faça login com sua nova senha.
  ✅ modal fechou
  ✅ login com a senha nova funciona
  ✅ senha antiga rejeitada (URL: http://localhost:5173/login)

-- reset com e-mail SEM conta --
  toasts: ["Se este e-mail estiver cadastrado, enviamos um código. | Verifique sua caixa de entrada."]
  ✅ avanca para a mesma tela de codigo
  ✅ nenhum texto denuncia que a conta nao existe
  descricao: Se ninguem.aqui@edu.pucrs.br tiver uma conta, enviamos um código de 6 dígitos.
  ✅ nenhum token criado (2 -> 2)
  ✅ nenhuma conta criada por engano
```

### Build, lint e resíduos

```
$ npm run lint    -> exit 0
$ npm run build   -> ✓ built in 9.19s
$ npx tsc -b      -> exit 0
$ grep -rn "tokenId|data\.id" src/ --exclude-dir=sdk   -> sem resultado
```

## 📌 Notas adicionais

**Diff do SDK** (regerado contra o back local, commit separado): exatamente os 5 endpoints previstos, nada mais.

- `ResetPasswordRequestResponseDTO` e `SignupRequestResponseDTO`: `id`/`expiresAt`/`isRevoked` → `message`/`expiresInSeconds`;
- `ResetPasswordDTO`, `ValidateResetPasswordDTO`, `ValidateSignupDTO`: ganham `email?`, `tokenId` passa a opcional (marcado como deprecated pelo back);
- `ResetPasswordApi.md`/`SignupApi.md`: só a descrição do 200.

O último regen tinha sido no front#34 e desde então mergearam back #48–#57 — nenhum deles mexeu no contrato exposto, então o diff ficou restrito ao #57.

**Ordem de deploy.** O back já está em produção, então este PR não tem pré-requisito: quanto antes for ao ar, menor a janela com os dois fluxos mortos.

**Depois deste PR em produção**, o back pode remover a retrocompat do `tokenId` dos 3 DTOs de validate/reset — [back#61](https://github.com/Liga-de-Algoritmos-PUCRS/liga-platform-backend/issues/61), aberta junto com este PR e marcada para só mergear depois que este estiver em produção. Nada neste PR envia `tokenId`.

**Um comportamento intencional que parece regressão:** cadastro com e-mail já registrado agora mostra a mesma tela de código em vez de "This email is already in use". O aviso real chega por e-mail ao dono do endereço (limitado a um a cada 15 min pelo back). É o ponto inteiro do back#23 — o contrário reabriria a enumeração.
